### PR TITLE
Release Build executes dotnet publish to generate a single self contained exe

### DIFF
--- a/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/VoiceAssistantTest.csproj
+++ b/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/VoiceAssistantTest.csproj
@@ -11,6 +11,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile></DocumentationFile>
+    <PostBuildEvent></PostBuildEvent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -56,6 +57,6 @@
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="dotnet publish -c Release -r win-x64 /p:PublishSingleFile=true /p:NoBuild=true"/>
+    <Exec Command="dotnet publish -c $(Configuration) -r win-x64 /p:PublishSingleFile=true /p:NoBuild=true"/>
   </Target>
 </Project>


### PR DESCRIPTION
## Purpose
Dotnet Publish is no longer needed. On successful Debug or Release build, dotnet publish is executed to generate a self contained single exe in the publish folder

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
```
cd to Project Directory
dotnet build
cd bin/Release/netcoreapp3.1/win-x64/publish
VoiceAssistant.exe {Path to Configuration File}
```

## What to Check
* VoiceAssistantTest.exe and .pdb are created in the win-x64/publish folder