### PR TITLE
Fix case where InputFolder and OutputFolder are missing in app config

### DIFF
--- a/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/AppSettings.cs
+++ b/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/AppSettings.cs
@@ -87,13 +87,13 @@ namespace VoiceAssistantTest
         /// Gets or sets the root input folder. This root folder will be added
         /// to all file names listed in the InputFiles array.
         /// </summary>
-        public string InputFolder { get; set; }
+        public string InputFolder { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the output folder. Test result and application
         /// log file will be written to this folder.
         /// </summary>
-        public string OutputFolder { get; set; }
+        public string OutputFolder { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether a Bot has a Greeting.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Path.Combine() cannot take null strings, they have to be empty string. So make sure we have a proper default when InputFolder and/or OutputFolder are not present in the app config

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
