### PR TITLE
Write to standard error stream if test fails

### DIFF
--- a/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/Program.cs
+++ b/samples/clients/csharp-dotnet-core/voice-assistant-test/tool/Program.cs
@@ -28,11 +28,13 @@ namespace VoiceAssistantTest
                 }
                 else
                 {
+                    Console.Error.WriteLine("Test failed");
                     return 1;
                 }
             }
             catch (Exception e)
             {
+                Console.Error.WriteLine("Test encountered exception");
                 System.Diagnostics.Trace.TraceError(e.ToString());
                 return 1;
             }


### PR DESCRIPTION
## Purpose
* Write to standard error stream if a test fails or encounters an exception. This is to allow use of failOnStderr argument in Command Line ADO Task. Task will fail if standard error stream contains content. 

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe: