### PR TITLE
Suppress error dialogs generated in response to graceful timeouts

### DIFF
--- a/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -337,13 +337,25 @@ namespace VoiceAssistantClient
 
         private void Connector_Canceled(object sender, SpeechRecognitionCanceledEventArgs e)
         {
-            var err = $"Error {e.ErrorCode} : {e.ErrorDetails}";
-            this.UpdateStatus(err);
-            this.RunOnUiThread(() =>
+            if (e.Reason == CancellationReason.Error
+                && e.ErrorCode == CancellationErrorCode.ConnectionFailure
+                && e.ErrorDetails.Contains("1000"))
             {
-                this.ListeningState = ListenState.NotListening;
-                this.Messages.Add(new MessageDisplay(err, Sender.Channel));
-            });
+                // A graceful timeout after a connection is idle manifests as an error but isn't an
+                // exceptional condition--we don't want it show up as a big red bubble!
+                this.UpdateStatus("Active connection timed out but ready to reconnect on demand.");
+            }
+            else
+            {
+                var statusMessage = $"Error ({e.ErrorCode}) : {e.ErrorDetails}";
+                this.UpdateStatus(statusMessage);
+                this.RunOnUiThread(() =>
+                {
+                    this.ListeningState = ListenState.NotListening;
+                    this.Messages.Add(new MessageDisplay(statusMessage, Sender.Channel));
+                });
+            }
+
         }
 
         private void Connector_Recognized(object sender, SpeechRecognitionEventArgs e)


### PR DESCRIPTION
## Purpose
There's a specific error that the service produces when a timeout gracefully disconnects via timeout (standard: 5 minutes). We currently present this error just like any other one, but that's causing a common misperception that something is wrong. This isn't an exceptional condition and so we shouldn't present it as such. The fix just suppresses the big red bubble and keeps a more useful explanation in the status box at the bottom of hte tool.

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the code. Connect to a bot or Custom Commands application. Let the connection sit for about five minutes. Verify that no error bubble is produced and that the status text at the bottom is updated. Verify that future interactions still work as intended (with an implicit reconnect).
