### PR TITLE
Cancel ongoing audio output upon session start (button press, KWS)

### DIFF
--- a/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -332,6 +332,7 @@ namespace VoiceAssistantClient
         {
             Debug.WriteLine($"SessionStarted event, id = {e.SessionId}");
             this.UpdateStatus("Listening ...");
+            this.player.Stop();
             this.RunOnUiThread(() => this.ListeningState = ListenState.Listening);
         }
 


### PR DESCRIPTION
## Purpose
Partners have requested information about how to implement "barge in;" more specifically, ensuring that a new interaction (e.g. via a keyword) can interrupt an ongoing existing interaction. This is a pretty simple thing to achieve and a decent default behavior, so it should be reflected in the Voice Assistant client.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Trigger a longer response from a bot, e.g. a long utterance to an echo bot
* During playback, press the mic icon or say a keyword
* Observe that the ongoing playback stops as listening begins for the next interaction
