### PR TITLE
Update doc for Windows Voice Assistant Client to address connection timeout

### DIFF
--- a/samples/clients/csharp-wpf/README.md
+++ b/samples/clients/csharp-wpf/README.md
@@ -60,15 +60,18 @@ The message **New conversation started -- type or press the microphone button** 
 ## Troubleshooting
 
 If an error messages was shown in red in the main application window, use this table to troubleshoot:
-
 | Error | What should you do? |
 |-------|----------------------|
 |Error AuthenticationFailure : WebSocket Upgrade failed with an authentication error (401). Please check for correct subscription key (or authorization token) and region name| In the Settings page of the application, make sure you entered the Speech Subscription key and its region correctly.|
 |Error ConnectionFailure : Connection was closed by the remote host. Error code: 1011. Error details: We could not connect to the bot before sending a message | Make sure you [checked the "Enable Streaming Endpoint" box and/or toggled "Web sockets" to On](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-channel-connect-directlinespeech?view=azure-bot-service-4.0#enable-the-bot-framework-protocol-streaming-extensions)<br>Make sure your Azure App Service is running. If it is, try restarting your App Service.|
 |Error ConnectionFailure : Connection was closed by the remote host. Error code: 1011. Error details: Response status code does not indicate success: 500 (InternalServerError)| Your bot specified a Neural Voice in its output Activity [Speak](https://github.com/microsoft/botframework-sdk/blob/master/specs/botframework-activity/botframework-activity.md#speak) field, but the Azure region associated with your Speech subscription key does not support Neural Voices. See [Standard and neural voices](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/regions#standard-and-neural-voices).|
-|Error ConnectionFailure : Connection was closed by the remote host. Error code: 1000. Error details: Exceeded maximum websocket connection idle duration(> 300000ms)| This is an expected error when the client left the connection to the channel open for more than 5 minutes without any activity |
+
 
 See also _Debugging_ section in [Voice-first virtual assistants Preview: Frequently asked questions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/faq-voice-first-virtual-assistants#debugging)
+
+### A note on connection time out
+
+If you are connected to a bot or custom command application and no activity happened in the last 5 minutes, the service will automatically close the websocket connection with the client and with the bot. This is by design. A message will appear in the bottom bar: *"Active connection timed out but ready to reconnect on demand"*. You do not need to press the "Reconnect" button - simply press the microphone button and start talking, type in a text message, or say the keyword (if one is enabled). The connection will automatically be reestablished.  
 
 ## Sending custom activities to your bot
 

--- a/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/samples/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -342,8 +342,11 @@ namespace VoiceAssistantClient
                 && e.ErrorCode == CancellationErrorCode.ConnectionFailure
                 && e.ErrorDetails.Contains("1000"))
             {
+                // Connection was closed by the remote host.
+                // Error code: 1000.
+                // Error details: Exceeded maximum websocket connection idle duration (>300000ms = 5 minutes).
                 // A graceful timeout after a connection is idle manifests as an error but isn't an
-                // exceptional condition--we don't want it show up as a big red bubble!
+                // exceptional condition -- we don't want it show up as a big red bubble!
                 this.UpdateStatus("Active connection timed out but ready to reconnect on demand.");
             }
             else


### PR DESCRIPTION
## Purpose
Per previous change from Travis, we no longer display the connection timeout cancellation event as a red-text error bubble in the main dialog window. Therefore updating the tool's README to describe the new behavior. Also give some more details as comment in the source code.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```