### PR TITLE
Add support for BotId

### DIFF
--- a/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -194,6 +194,7 @@ namespace VoiceAssistantClient
 
             var hasSubscription = !string.IsNullOrWhiteSpace(this.settings.RuntimeSettings.Profile.SubscriptionKey);
             var hasRegion = !string.IsNullOrWhiteSpace(this.settings.RuntimeSettings.Profile.SubscriptionKeyRegion);
+            var hasBotId = !string.IsNullOrWhiteSpace(this.settings.RuntimeSettings.Profile.BotId);
             var hasUrlOverride = !string.IsNullOrWhiteSpace(this.settings.RuntimeSettings.Profile.UrlOverride);
 
             if (hasSubscription && (hasRegion || hasUrlOverride))
@@ -206,6 +207,10 @@ namespace VoiceAssistantClient
                     // - Cognitive services speech subscription key.
                     // - The Azure region of the subscription key(e.g. "westus").
                     config = CustomCommandsConfig.FromSubscription(this.settings.RuntimeSettings.Profile.CustomCommandsAppId, this.settings.RuntimeSettings.Profile.SubscriptionKey, this.settings.RuntimeSettings.Profile.SubscriptionKeyRegion);
+                }
+                else if (hasBotId)
+                {
+                    config = BotFrameworkConfig.FromSubscription(this.settings.RuntimeSettings.Profile.SubscriptionKey, this.settings.RuntimeSettings.Profile.SubscriptionKeyRegion, botId: this.settings.RuntimeSettings.Profile.BotId);
                 }
                 else
                 {

--- a/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -210,7 +210,7 @@ namespace VoiceAssistantClient
                 }
                 else if (hasBotId)
                 {
-                    config = BotFrameworkConfig.FromSubscription(this.settings.RuntimeSettings.Profile.SubscriptionKey, this.settings.RuntimeSettings.Profile.SubscriptionKeyRegion, botId: this.settings.RuntimeSettings.Profile.BotId);
+                    config = BotFrameworkConfig.FromSubscription(this.settings.RuntimeSettings.Profile.SubscriptionKey, this.settings.RuntimeSettings.Profile.SubscriptionKeyRegion, this.settings.RuntimeSettings.Profile.BotId);
                 }
                 else
                 {

--- a/clients/csharp-wpf/VoiceAssistantClient/Settings/ConnectionProfile.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Settings/ConnectionProfile.cs
@@ -14,6 +14,8 @@ namespace VoiceAssistantClient.Settings
 
         public string CustomCommandsAppId { get; set; }
 
+        public string BotId { get; set; }
+
         public string ConnectionLanguage { get; set; }
 
         public string LogFilePath { get; set; }

--- a/clients/csharp-wpf/VoiceAssistantClient/Settings/RuntimeSettings.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Settings/RuntimeSettings.cs
@@ -23,6 +23,7 @@ namespace VoiceAssistantClient.Settings
         private string subscriptionKey;
         private string subscriptionKeyRegion;
         private string customCommandsAppId;
+        private string botId;
         private string language;
         private string logFilePath;
         private string customSpeechEndpointId;
@@ -79,6 +80,12 @@ namespace VoiceAssistantClient.Settings
         {
             get => this.customCommandsAppId;
             set => this.SetProperty(ref this.customCommandsAppId, value);
+        }
+
+        public string BotId
+        {
+            get => this.botId;
+            set => this.SetProperty(ref this.botId, value);
         }
 
         public string Language

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
@@ -47,6 +47,7 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
                 </Grid.RowDefinitions>
 
                 <Label  Grid.Row="0" Grid.Column="0" Content="General settings:" FontWeight="Bold" />
@@ -60,14 +61,17 @@
                 <Label Grid.Row="3" Grid.Column="0" Content="Custom commands app Id:"/>
                 <ComboBox Grid.Row="3" Grid.Column="1" Name="CustomCommandsAppIdComboBox" IsEditable="True"  Padding="5" TextBoxBase.TextChanged="CustomCommandsAppIdTextBox_TextChanged"  Text="{Binding CustomCommandsAppId}"/>
 
-                <Label Grid.Row="4" Grid.Column="0" Content="User From Id:"/>
-                <TextBox Grid.Row="4" Grid.Column="1" Name='FromIdTextBox' Text="{Binding FromId}"/>
+                <Label Grid.Row="4" Grid.Column="0" Content="Bot Id:"/>
+                <TextBox Grid.Row="4" Grid.Column="1" Name="BotIdTextBox" Text="{Binding BotId}"/>
+                
+                <Label Grid.Row="5" Grid.Column="0" Content="User From Id:"/>
+                <TextBox Grid.Row="5" Grid.Column="1" Name='FromIdTextBox' Text="{Binding FromId}"/>
 
-                <Label  Grid.Row="5" Grid.Column="0" Content="Language:"/>
-                <TextBox Grid.Row="5" Grid.Column="1" Name='LanguageTextBox'  Text="{Binding ConnectionLanguage}" />
+                <Label  Grid.Row="6" Grid.Column="0" Content="Language:"/>
+                <TextBox Grid.Row="6" Grid.Column="1" Name='LanguageTextBox'  Text="{Binding ConnectionLanguage}" />
 
-                <Label  Grid.Row="6" Grid.Column="0" Content="Log file path:"/>
-                <TextBox Grid.Row="6" Grid.Column="1"  Name="LogFileTextBox" Text="{Binding LogFilePath}"/>
+                <Label  Grid.Row="7" Grid.Column="0" Content="Log file path:"/>
+                <TextBox Grid.Row="7" Grid.Column="1"  Name="LogFileTextBox" Text="{Binding LogFilePath}"/>
             </Grid>
 
             <Grid Margin="0,5,5,0">

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -52,11 +52,13 @@ namespace VoiceAssistantClient
 
         public Dictionary<string, ConnectionProfile> ConnectionProfile { get; set; }
 
-        public string SubscriptionKey { get; set; }
+        public string SubscriptionKey { get => this.settings.Profile.SubscriptionKey; set => this.settings.Profile.SubscriptionKey = value; }
 
         public string SubscriptionKeyRegion { get; set; }
 
         public string CustomCommandsAppId { get; set; }
+
+        public string BotId { get; set; }
 
         public string ConnectionLanguage { get; set; }
 
@@ -102,11 +104,11 @@ namespace VoiceAssistantClient
             this.ConnectionProfileComboBox.ItemsSource = this.settings.ConnectionProfileNameHistory;
             this.ConnectionProfileComboBox.Text = this.ConnectionProfileName;
             this.SubscriptionKeyComboBox.ItemsSource = this.settings.CognitiveServiceKeyHistory;
-            this.SubscriptionKeyComboBox.Text = this.settings.SubscriptionKey;
+            this.SubscriptionKeyComboBox.Text = this.settings.Profile.SubscriptionKey;
             this.SubscriptionRegionComboBox.ItemsSource = this.settings.CognitiveServiceRegionHistory;
-            this.SubscriptionRegionComboBox.Text = this.settings.SubscriptionKeyRegion;
+            this.SubscriptionRegionComboBox.Text = this.settings.Profile.SubscriptionKeyRegion;
             this.CustomCommandsAppIdComboBox.ItemsSource = this.settings.CustomCommandsAppIdHistory;
-            this.CustomCommandsAppIdComboBox.Text = this.settings.CustomCommandsAppId;
+            this.CustomCommandsAppIdComboBox.Text = this.settings.Profile.CustomCommandsAppId;
             base.OnActivated(e);
         }
 
@@ -119,6 +121,7 @@ namespace VoiceAssistantClient
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey = this.SubscriptionKeyComboBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].BotId = this.BotIdTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].ConnectionLanguage = this.LanguageTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].LogFilePath = this.LogFileTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].UrlOverride = this.UrlOverrideTextBox.Text;
@@ -136,6 +139,7 @@ namespace VoiceAssistantClient
                     this.settings.Profile.SubscriptionKey = this.SubscriptionKeyComboBox.Text;
                     this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
                     this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+                    this.settings.Profile.BotId = this.BotIdTextBox.Text;
                     this.settings.Profile.ConnectionLanguage = this.LanguageTextBox.Text;
                     this.settings.Profile.LogFilePath = this.LogFileTextBox.Text;
                     this.settings.Profile.UrlOverride = this.UrlOverrideTextBox.Text;
@@ -157,6 +161,7 @@ namespace VoiceAssistantClient
                         SubscriptionKey = this.SubscriptionKey,
                         SubscriptionKeyRegion = this.SubscriptionKeyRegion,
                         CustomCommandsAppId = this.CustomCommandsAppId,
+                        BotId = this.BotId,
                         ConnectionLanguage = this.ConnectionLanguage,
                         LogFilePath = this.LogFilePath,
                         UrlOverride = this.UrlOverride,
@@ -516,6 +521,7 @@ namespace VoiceAssistantClient
                     this.SubscriptionKeyComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey;
                     this.SubscriptionRegionComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion;
                     this.CustomCommandsAppIdComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId;
+                    this.BotIdTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].BotId;
                     this.LanguageTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].ConnectionLanguage;
                     this.LogFileTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].LogFilePath;
                     this.UrlOverrideTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].UrlOverride;
@@ -534,6 +540,7 @@ namespace VoiceAssistantClient
                     this.SubscriptionKeyComboBox.Text = string.Empty;
                     this.SubscriptionRegionComboBox.Text = string.Empty;
                     this.CustomCommandsAppIdComboBox.Text = string.Empty;
+                    this.BotIdTextBox.Text = string.Empty;
                     this.LanguageTextBox.Text = string.Empty;
                     this.LogFileTextBox.Text = string.Empty;
                     this.UrlOverrideTextBox.Text = string.Empty;

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -52,7 +52,7 @@ namespace VoiceAssistantClient
 
         public Dictionary<string, ConnectionProfile> ConnectionProfile { get; set; }
 
-        public string SubscriptionKey { get => this.settings.Profile.SubscriptionKey; set => this.settings.Profile.SubscriptionKey = value; }
+        public string SubscriptionKey { get; set; }
 
         public string SubscriptionKeyRegion { get; set; }
 

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -111,19 +111,6 @@ namespace VoiceAssistantClient
             this.SubscriptionRegionComboBox.Text = this.settings.Profile.SubscriptionKeyRegion;
             this.CustomCommandsAppIdComboBox.ItemsSource = this.settings.CustomCommandsAppIdHistory;
             this.CustomCommandsAppIdComboBox.Text = this.settings.Profile.CustomCommandsAppId;
-            this.BotIdTextBox.Text = this.settings.Profile.BotId;
-            this.FromIdTextBox.Text = this.settings.Profile.FromId;
-            this.LanguageTextBox.Text = this.settings.Profile.ConnectionLanguage;
-            this.LogFileTextBox.Text = this.settings.Profile.LogFilePath;
-            this.CustomSpeechEndpointIdTextBox.Text = this.settings.Profile.CustomSpeechEndpointId;
-            this.CustomSpeechEnabledBox.IsChecked = this.settings.Profile.CustomSpeechEnabled;
-            this.VoiceDeploymentIdsTextBox.Text = this.settings.Profile.VoiceDeploymentIds;
-            this.VoiceDeploymentEnabledBox.IsChecked = this.settings.Profile.VoiceDeploymentEnabled;
-            this.WakeWordPathTextBox.Text = this.settings.Profile.WakeWordPath;
-            this.WakeWordEnabledBox.IsChecked = this.settings.Profile.WakeWordEnabled;
-            this.UrlOverrideTextBox.Text = this.settings.Profile.UrlOverride;
-            this.ProxyHost.Text = this.settings.Profile.ProxyHostName;
-            this.ProxyPort.Text = this.settings.Profile.ProxyPortNumber;
             base.OnActivated(e);
         }
 
@@ -549,7 +536,7 @@ namespace VoiceAssistantClient
                     this.CustomSpeechEnabledBox.IsChecked = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomSpeechEnabled;
                     this.VoiceDeploymentIdsTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentIds;
                     this.VoiceDeploymentEnabledBox.IsChecked = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentEnabled;
-                    this.WakeWordPathTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordConfig.Path;
+                    this.WakeWordPathTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath;
                     this.WakeWordEnabledBox.IsChecked = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled;
                 }
                 else

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -72,6 +72,8 @@ namespace VoiceAssistantClient
 
         public string FromId { get; set; }
 
+        public string WakeWordPath { get; set; }
+
         public WakeWordConfiguration WakeWordConfig { get; set; }
 
         public bool WakeWordEnabled { get; set; }
@@ -109,6 +111,19 @@ namespace VoiceAssistantClient
             this.SubscriptionRegionComboBox.Text = this.settings.Profile.SubscriptionKeyRegion;
             this.CustomCommandsAppIdComboBox.ItemsSource = this.settings.CustomCommandsAppIdHistory;
             this.CustomCommandsAppIdComboBox.Text = this.settings.Profile.CustomCommandsAppId;
+            this.BotIdTextBox.Text = this.settings.Profile.BotId;
+            this.FromIdTextBox.Text = this.settings.Profile.FromId;
+            this.LanguageTextBox.Text = this.settings.Profile.ConnectionLanguage;
+            this.LogFileTextBox.Text = this.settings.Profile.LogFilePath;
+            this.CustomSpeechEndpointIdTextBox.Text = this.settings.Profile.CustomSpeechEndpointId;
+            this.CustomSpeechEnabledBox.IsChecked = this.settings.Profile.CustomSpeechEnabled;
+            this.VoiceDeploymentIdsTextBox.Text = this.settings.Profile.VoiceDeploymentIds;
+            this.VoiceDeploymentEnabledBox.IsChecked = this.settings.Profile.VoiceDeploymentEnabled;
+            this.WakeWordPathTextBox.Text = this.settings.Profile.WakeWordPath;
+            this.WakeWordEnabledBox.IsChecked = this.settings.Profile.WakeWordEnabled;
+            this.UrlOverrideTextBox.Text = this.settings.Profile.UrlOverride;
+            this.ProxyHost.Text = this.settings.Profile.ProxyHostName;
+            this.ProxyPort.Text = this.settings.Profile.ProxyPortNumber;
             base.OnActivated(e);
         }
 
@@ -132,8 +147,9 @@ namespace VoiceAssistantClient
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomSpeechEnabled = (bool)this.CustomSpeechEnabledBox.IsChecked;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentIds = this.VoiceDeploymentIdsTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentEnabled = (bool)this.VoiceDeploymentEnabledBox.IsChecked;
-                    var wakeWordPath = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordConfig.Path;
-                    wakeWordPath = this.WakeWordPathTextBox.Text;
+                    var wakeWordConfigPath = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordConfig.Path;
+                    wakeWordConfigPath = this.WakeWordPathTextBox.Text;
+                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath = this.WakeWordPathTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled = (bool)this.WakeWordEnabledBox.IsChecked;
 
                     this.settings.Profile.SubscriptionKey = this.SubscriptionKeyComboBox.Text;
@@ -168,6 +184,7 @@ namespace VoiceAssistantClient
                         ProxyHostName = this.ProxyHostName,
                         ProxyPortNumber = this.ProxyPortNumber,
                         FromId = this.FromId,
+                        WakeWordPath = this.WakeWordPath,
                         WakeWordConfig = this.WakeWordConfig,
                         CustomSpeechConfig = this.CustomSpeechConfig,
                         CustomSpeechEndpointId = this.CustomSpeechEndpointId,


### PR DESCRIPTION
## Purpose
* BotFrameworkConfig.FromSubscription() contains a parameter called BotId. This PR enables setting a Bot Handle along with the Subscription Key and Subscription Region.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
*  Add Subscription Key, Subscription Region, and BotId to a Connection Profile to connect