### PR TITLE
Update artifact names. Also prep for building UWP Voice Assistant Sample (not yet enabled)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ pr:
     
 pool: 'Voice Assistant Agent Pool'
 
+
 variables:
 
   # Common Build configurations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,7 @@ pr:
     include:
     - master
     
-pool:
-  vmImage: 'windows-latest'
+pool: 'Voice Assistant Agent Pool'
 
 variables:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,12 +105,12 @@ steps:
 # Build Windows Voice Assistant Client (C#, WPF)
 
 - task: NuGetCommand@2
-  displayName: 'NuGetCommand - $(sample1Name)'
+  displayName: '$(sample1Name) - NuGetCommand'
   inputs:
     restoreSolution: '$(sample1Solution)'
 
 - task: VSBuild@1
-  displayName: 'VSBuild - $(sample1Name)'
+  displayName: '$(sample1Name) - VSBuild'
   inputs:
     solution: '$(sample1Solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
@@ -128,7 +128,7 @@ steps:
     SessionTimeout: '60'
 
 - task: PublishPipelineArtifact@1
-  displayName: 'PublishPipelineArtifact - $(sample1Name)'
+  displayName: '$(sample1Name) - PublishPipelineArtifact'
   inputs:
     path: $(sample1PublishedArtifactPath)
     artifact: $(sample1PublishedArtifactName)
@@ -136,17 +136,17 @@ steps:
 # Build Voice Assistant Test (C# .NET Core)
 
 - task: DotNetCoreCLI@2
-  displayName: 'DotNetCoreCLI - $(sample2Name)'
+  displayName: '$(sample2Name) - DotNetCoreCLI'
   inputs:
     Command: 'publish'
     Projects: $(sample2Solution)
     publishWebProjects: false
-    Arguments: '-r $(dotNetCoreRuntimeIdentifier) -c $(buildConfiguration) -o $(dotNetCorePublishArtifactPath)  /p:PublishSingleFile=true'
+    Arguments: '-r $(dotNetCoreRuntimeIdentifier) -c $(buildConfiguration) -o $(sample2PublishedArtifactPath)  /p:PublishSingleFile=true'
     zipAfterPublish: false
     modifyOutputPath: true    
 
 - task: PublishPipelineArtifact@1
-  displayName: 'PublishPipelineArtifact - $(sample2Name)'
+  displayName: '$(sample2Name) - PublishPipelineArtifact'
   inputs:
     path: $(sample2PublishedArtifactPath)
     artifact: $(sample2PublishedArtifactName)
@@ -154,12 +154,12 @@ steps:
 # Build C++ console application
 
 - task: NuGetCommand@2
-  displayName: 'NuGetCommand - $(sample3Name)'
+  displayName: '$(sample3Name) - NuGetCommand'
   inputs:
     restoreSolution: '$(sample3Solution)'
     
 - task: VSBuild@1
-  displayName: 'VSBuild - $(sample3Name)'
+  displayName: '$(sample3Name) - VSBuild'
   inputs:
     solution: '$(sample3Solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
@@ -169,12 +169,12 @@ steps:
 # Build UWP Voice Assistant Sample (C# UWP)
 
 - task: NuGetCommand@2
-  displayName: 'NuGetCommand - $(sample4Name)'
+  displayName: '$(sample4Name) - NuGetCommand'
   inputs:
     restoreSolution: '$(sample4Solution)'
 
 - task: VSBuild@1
-  displayName: 'VSBuild - $(sample4Name)'
+  displayName: '$(sample4Name) - VSBuild'
   inputs:
     solution: '$(sample4Solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
@@ -182,7 +182,7 @@ steps:
     configuration: '$(buildConfiguration)'
 
 - task: PublishPipelineArtifact@1
-  displayName: 'PublishPipelineArtifact - $(sample4Name)'
+  displayName: '$(sample4Name) - PublishPipelineArtifact'
   inputs:
     path: $(sample4PublishedArtifactPath)
     artifact: $(sample4PublishedArtifactName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,6 @@ variables:
   buildConfiguration: Release
   dotNetCoreRuntimeIdentifier: win-x64 
   dotNetCoreVersion: '3.1'
-  dotNetCorePublishArtifactPath: 'DotNetCorePublish'
-  dotNetCorePublishArtifactName: 'DotNetCoreExecutables'
 
   # Sample 1: Windows Voice Assistant Client, C# WPF (\clients\csharp-wpf)
   sample1Name: VoiceAssistantClient
@@ -43,7 +41,9 @@ variables:
   sample2Name: VoiceAssistantTest
   sample2Folder: 'clients\csharp-dotnet-core\voice-assistant-test\tool'
   sample2Solution: '$(sample2Folder)\$(sample2Name).sln'
-  
+  sample2PublishedArtifactPath: 'DotNetCorePublish'
+  sample2PublishedArtifactName: 'DotNetCoreExecutables'
+
   # Sample 3: Windows console Voice Assistant Client, C++ (\clients\cpp-console)
   sample3Name: VoiceAssistantCPPClient
   sample3Folder: 'clients\cpp-console'
@@ -102,11 +102,12 @@ steps:
 
 - task: NuGetToolInstaller@1
 
+# Build Windows Voice Assistant Client (C#, WPF)
+
 - task: NuGetCommand@2
+  displayName: 'NuGetCommand - $(sample1Name)'
   inputs:
     restoreSolution: '$(sample1Solution)'
-
-# Build Windows Voice Assistant Client (C#, WPF)
 
 - task: VSBuild@1
   displayName: 'VSBuild - $(sample1Name)'
@@ -127,7 +128,7 @@ steps:
     SessionTimeout: '60'
 
 - task: PublishPipelineArtifact@1
-  displayName: 'PublishPipelineArtifact - Publish artifacts for $(sample1Name)'
+  displayName: 'PublishPipelineArtifact - $(sample1Name)'
   inputs:
     path: $(sample1PublishedArtifactPath)
     artifact: $(sample1PublishedArtifactName)
@@ -135,7 +136,7 @@ steps:
 # Build Voice Assistant Test (C# .NET Core)
 
 - task: DotNetCoreCLI@2
-  displayName: 'DotNetCoreCLI - .NET Core build and publish $(sample2Name)'
+  displayName: 'DotNetCoreCLI - $(sample2Name)'
   inputs:
     Command: 'publish'
     Projects: $(sample2Solution)
@@ -145,19 +146,20 @@ steps:
     modifyOutputPath: true    
 
 - task: PublishPipelineArtifact@1
-  displayName: 'PublishPipelineArtifact - Publish artifacts for .NET core executables'
+  displayName: 'PublishPipelineArtifact - $(sample2Name)'
   inputs:
-    path: $(dotNetCorePublishArtifactPath)
-    artifact: $(dotNetCorePublishArtifactName)
+    path: $(sample2PublishedArtifactPath)
+    artifact: $(sample2PublishedArtifactName)
     
-# Build cpp console application (C++)
+# Build C++ console application
 
 - task: NuGetCommand@2
+  displayName: 'NuGetCommand - $(sample3Name)'
   inputs:
     restoreSolution: '$(sample3Solution)'
     
 - task: VSBuild@1
-  displayName: 'VSCPPBuild - $(sample3Name)'
+  displayName: 'VSBuild - $(sample3Name)'
   inputs:
     solution: '$(sample3Solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
@@ -167,6 +169,7 @@ steps:
 # Build UWP Voice Assistant Sample (C# UWP)
 
 - task: NuGetCommand@2
+  displayName: 'NuGetCommand - $(sample4Name)'
   inputs:
     restoreSolution: '$(sample4Solution)'
 
@@ -177,6 +180,12 @@ steps:
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
     platform: '$(buildPlatformNative)'
     configuration: '$(buildConfiguration)'
+
+- task: PublishPipelineArtifact@1
+  displayName: 'PublishPipelineArtifact - $(sample4Name)'
+  inputs:
+    path: $(sample4PublishedArtifactPath)
+    artifact: $(sample4PublishedArtifactName)
 
 #- task: VSTest@2
 #  inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,11 @@ pr:
     include:
     - master
     
-pool: 'Voice Assistant Agent Pool'
+pool:
+  vmImage: 'windows-latest'
+
+# Use this when build agents are ready:
+# pool: 'Voice Assistant Agent Pool'
 
 
 variables:
@@ -35,28 +39,28 @@ variables:
   sample1Folder: 'clients\csharp-wpf'
   sample1Solution: '$(sample1Folder)\$(sample1Name).sln'
   sample1PublishedArtifactPath: '$(sample1Folder)\$(sample1Name)\bin\$(buildPlatformNative)\$(buildConfiguration)'
-  sample1PublishedArtifactName: 'WindowsVoiceAssistantClientBuild'
+  sample1PublishedArtifactName: 'WindowsVoiceAssistantClient-$(Build.BuildNumber)''
 
   # Sample 2: Voice Assistant Test, .NET core (\clients\csharp-dotnet-core\voice-assistant-test)
   sample2Name: VoiceAssistantTest
   sample2Folder: 'clients\csharp-dotnet-core\voice-assistant-test\tool'
   sample2Solution: '$(sample2Folder)\$(sample2Name).sln'
   sample2PublishedArtifactPath: 'DotNetCorePublish'
-  sample2PublishedArtifactName: 'DotNetCoreExecutables'
+  sample2PublishedArtifactName: 'VoiceAssistantTest-$(Build.BuildNumber)'
 
   # Sample 3: Windows console Voice Assistant Client, C++ (\clients\cpp-console)
   sample3Name: VoiceAssistantCPPClient
   sample3Folder: 'clients\cpp-console'
   sample3Solution: '$(sample3Folder)\src\windows\cppSample.sln'
   sample3PublishedArtifactPath: '$(sample3Folder)\out'
-  sample3PublishedArtifactName: 'CppSample'
+  sample3PublishedArtifactName: 'CppSample-$(Build.BuildNumber)'
  
   # Sample 4: UWP Voice Assistant Sample (\clients\csharp-uwp)
   sample4Name: UWPVoiceAssistantSample
   sample4Folder: 'clients\csharp-uwp'
   sample4Solution: '$(sample4Folder)\$(sample4Name).sln'
   sample4PublishedArtifactPath: '$(sample4Folder)\$(sample4Name)\bin\$(buildPlatformNative)\$(buildConfiguration)'
-  sample4PublishedArtifactName: '$(sample4Name)'
+  sample4PublishedArtifactName: '$(sample4Name)-$(Build.BuildNumber)'
 
   # ESRP code signing
   signParams: |
@@ -118,7 +122,7 @@ steps:
     configuration: '$(buildConfiguration)'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'Code sign $(sample1Name)'
+  displayName: '$(sample1Name) - EsrpCodeSigning'
   inputs:
     ConnectedServiceName: 'Voice Assistant Sample Code ESRP Signing' 
     signConfigType: inlineSignParams
@@ -168,26 +172,24 @@ steps:
 
 # Build UWP Voice Assistant Sample (C# UWP)
 
-- task: NuGetCommand@2
-  displayName: '$(sample4Name) - NuGetCommand'
-  inputs:
-    restoreSolution: '$(sample4Solution)'
+#- task: NuGetCommand@2
+#  displayName: '$(sample4Name) - NuGetCommand'
+#  inputs:
+#    restoreSolution: '$(sample4Solution)'
 
-- task: VSBuild@1
-  displayName: '$(sample4Name) - VSBuild'
-  inputs:
-    solution: '$(sample4Solution)'
-    msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
-    platform: '$(buildPlatformNative)'
-    configuration: '$(buildConfiguration)'
+#- task: VSBuild@1
+#  displayName: '$(sample4Name) - VSBuild'
+#  inputs:
+#    solution: '$(sample4Solution)'
+#    msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+#    platform: '$(buildPlatformNative)'
+#    configuration: '$(buildConfiguration)'
 
-#     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
-
-- task: PublishPipelineArtifact@1
-  displayName: '$(sample4Name) - PublishPipelineArtifact'
-  inputs:
-    path: $(sample4PublishedArtifactPath)
-    artifact: $(sample4PublishedArtifactName)
+#- task: PublishPipelineArtifact@1
+#  displayName: '$(sample4Name) - PublishPipelineArtifact'
+#  inputs:
+#    path: $(sample4PublishedArtifactPath)
+#    artifact: $(sample4PublishedArtifactName)
 
 #- task: VSTest@2
 #  inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ variables:
   sample2Name: VoiceAssistantTest
   sample2Folder: 'clients\csharp-dotnet-core\voice-assistant-test\tool'
   sample2Solution: '$(sample2Folder)\$(sample2Name).sln'
-  sample2PublishedArtifactPath: 'DotNetCorePublish'
+  sample2PublishedArtifactPath: '$(sample2Name)Publish'
   sample2PublishedArtifactName: 'VoiceAssistantTest-$(Build.BuildNumber)'
 
   # Sample 3: Windows console Voice Assistant Client, C++ (\clients\cpp-console)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,13 @@ variables:
   sample3Solution: '$(sample3Folder)\src\windows\cppSample.sln'
   sample3PublishedArtifactPath: '$(sample3Folder)\out'
   sample3PublishedArtifactName: 'CppSample'
+ 
+  # Sample 4: UWP Voice Assistant Sample (\clients\csharp-uwp)
+  sample4Name: UWPVoiceAssistantSample
+  sample4Folder: 'clients\csharp-uwp'
+  sample4Solution: '$(sample4Folder)\$(sample4Name).sln'
+  sample4PublishedArtifactPath: '$(sample4Folder)\$(sample4Name)\bin\$(buildPlatformNative)\$(buildConfiguration)'
+  sample4PublishedArtifactName: '$(sample4Name)'
 
   # ESRP code signing
   signParams: |
@@ -99,7 +106,8 @@ steps:
   inputs:
     restoreSolution: '$(sample1Solution)'
 
-# Build .Net Standard applications
+# Build Windows Voice Assistant Client (C#, WPF)
+
 - task: VSBuild@1
   displayName: 'VSBuild - $(sample1Name)'
   inputs:
@@ -124,7 +132,8 @@ steps:
     path: $(sample1PublishedArtifactPath)
     artifact: $(sample1PublishedArtifactName)
 
-# Build .NET Core applications and publish self-contained executables   
+# Build Voice Assistant Test (C# .NET Core)
+
 - task: DotNetCoreCLI@2
   displayName: 'DotNetCoreCLI - .NET Core build and publish $(sample2Name)'
   inputs:
@@ -135,14 +144,13 @@ steps:
     zipAfterPublish: false
     modifyOutputPath: true    
 
-# Include all .NET Core executables in the resulting artifacts 
 - task: PublishPipelineArtifact@1
   displayName: 'PublishPipelineArtifact - Publish artifacts for .NET core executables'
   inputs:
     path: $(dotNetCorePublishArtifactPath)
     artifact: $(dotNetCorePublishArtifactName)
     
-# Build cpp console application
+# Build cpp console application (C++)
 
 - task: NuGetCommand@2
   inputs:
@@ -152,6 +160,20 @@ steps:
   displayName: 'VSCPPBuild - $(sample3Name)'
   inputs:
     solution: '$(sample3Solution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
+    platform: '$(buildPlatformNative)'
+    configuration: '$(buildConfiguration)'
+
+# Build UWP Voice Assistant Sample (C# UWP)
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(sample4Solution)'
+
+- task: VSBuild@1
+  displayName: 'VSBuild - $(sample4Name)'
+  inputs:
+    solution: '$(sample4Solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
     platform: '$(buildPlatformNative)'
     configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
   sample1Folder: 'clients\csharp-wpf'
   sample1Solution: '$(sample1Folder)\$(sample1Name).sln'
   sample1PublishedArtifactPath: '$(sample1Folder)\$(sample1Name)\bin\$(buildPlatformNative)\$(buildConfiguration)'
-  sample1PublishedArtifactName: 'WindowsVoiceAssistantClient-$(Build.BuildNumber)''
+  sample1PublishedArtifactName: 'WindowsVoiceAssistantClient-$(Build.BuildNumber)'
 
   # Sample 2: Voice Assistant Test, .NET core (\clients\csharp-dotnet-core\voice-assistant-test)
   sample2Name: VoiceAssistantTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,9 +177,11 @@ steps:
   displayName: '$(sample4Name) - VSBuild'
   inputs:
     solution: '$(sample4Solution)'
-    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
+    msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
     platform: '$(buildPlatformNative)'
     configuration: '$(buildConfiguration)'
+
+#     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
 
 - task: PublishPipelineArtifact@1
   displayName: '$(sample4Name) - PublishPipelineArtifact'


### PR DESCRIPTION
* Update artifact names, including adding build number, since I am about to post some of them as GitHub releases
* Update display names for build tasks so they align nicely in the build log
* Add build task for UWP Voice Assistant Sample. Disabled until private build agent issues are fixed.