### PR TITLE
Fix for App losing scope and Delete Profile button

### DIFF
--- a/clients/csharp-wpf/JsonViewControl/JsonViewControl.csproj
+++ b/clients/csharp-wpf/JsonViewControl/JsonViewControl.csproj
@@ -50,9 +50,6 @@
     <RunCodeAnalysisRestore>False</RunCodeAnalysisRestore>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Build.Framework.16.5.0\lib\netstandard2.0\Microsoft.Build.Framework.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/clients/csharp-wpf/JsonViewControl/JsonViewControl.csproj
+++ b/clients/csharp-wpf/JsonViewControl/JsonViewControl.csproj
@@ -50,11 +50,21 @@
     <RunCodeAnalysisRestore>False</RunCodeAnalysisRestore>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.Framework.16.5.0\lib\netstandard2.0\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/clients/csharp-wpf/JsonViewControl/packages.config
+++ b/clients/csharp-wpf/JsonViewControl/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Build.Framework" version="16.5.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
@@ -8,4 +9,6 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.113" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.113" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net461" />
 </packages>

--- a/clients/csharp-wpf/JsonViewControl/packages.config
+++ b/clients/csharp-wpf/JsonViewControl/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Build.Framework" version="16.5.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />

--- a/clients/csharp-wpf/VoiceAssistantClient/App.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.Toolkit" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.7.0.0" newVersion="3.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.MarkedNet" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/clients/csharp-wpf/VoiceAssistantClient/Properties/AssemblyInfo.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyVersion("1.11.0.0")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/clients/csharp-wpf/VoiceAssistantClient/Settings/AppSettings.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Settings/AppSettings.cs
@@ -3,11 +3,6 @@
 
 namespace VoiceAssistantClient.Settings
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using Jot.DefaultInitializer;
 
     public class AppSettings

--- a/clients/csharp-wpf/VoiceAssistantClient/Settings/ConnectionProfile.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Settings/ConnectionProfile.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Windows.Documents;
-
 namespace VoiceAssistantClient.Settings
 {
     public class ConnectionProfile

--- a/clients/csharp-wpf/VoiceAssistantClient/Settings/RuntimeSettings.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/Settings/RuntimeSettings.cs
@@ -15,9 +15,6 @@ namespace VoiceAssistantClient.Settings
     {
         private ObservableCollection<string> connectionProfileNameHistory = new ObservableCollection<string>();
         private ObservableCollection<Dictionary<string, ConnectionProfile>> connectionProfileHistory = new ObservableCollection<Dictionary<string, ConnectionProfile>>();
-        private ObservableCollection<string> cognitiveServiceKeyHistory = new ObservableCollection<string>();
-        private ObservableCollection<string> cognitiveServiceRegionHistory = new ObservableCollection<string>();
-        private ObservableCollection<string> customCommandsAppIdHistory = new ObservableCollection<string>();
         private string connectionProfileName;
         private Dictionary<string, ConnectionProfile> connectionProfile = new Dictionary<string, ConnectionProfile>();
         private string subscriptionKey;
@@ -200,76 +197,14 @@ namespace VoiceAssistantClient.Settings
             }
         }
 
-        public ObservableCollection<string> CognitiveServiceKeyHistory
-        {
-            get
-            {
-                return this.cognitiveServiceKeyHistory;
-            }
-
-            set
-            {
-                if (this.cognitiveServiceKeyHistory != null)
-                {
-                    this.cognitiveServiceKeyHistory.CollectionChanged -= this.CognitiveServiceKeyHistory_CollectionChanged;
-                }
-
-                this.cognitiveServiceKeyHistory = value;
-                this.cognitiveServiceKeyHistory.CollectionChanged += this.CognitiveServiceKeyHistory_CollectionChanged;
-                this.OnPropertyChanged();
-            }
-        }
-
-        public ObservableCollection<string> CognitiveServiceRegionHistory
-        {
-            get
-            {
-                return this.cognitiveServiceRegionHistory;
-            }
-
-            set
-            {
-                if (this.cognitiveServiceRegionHistory != null)
-                {
-                    this.cognitiveServiceRegionHistory.CollectionChanged -= this.CognitiveServiceRegionHistory_CollectionChanged;
-                }
-
-                this.cognitiveServiceRegionHistory = value;
-                this.cognitiveServiceRegionHistory.CollectionChanged += this.CognitiveServiceRegionHistory_CollectionChanged;
-                this.OnPropertyChanged();
-            }
-        }
-
-        public ObservableCollection<string> CustomCommandsAppIdHistory
-        {
-            get
-            {
-                return this.customCommandsAppIdHistory;
-            }
-
-            set
-            {
-                if (this.customCommandsAppIdHistory != null)
-                {
-                    this.customCommandsAppIdHistory.CollectionChanged -= this.CustomCommandsAppIdHistory_CollectionChanged;
-                }
-
-                this.customCommandsAppIdHistory = value;
-                this.customCommandsAppIdHistory.CollectionChanged += this.CustomCommandsAppIdHistory_CollectionChanged;
-                this.OnPropertyChanged();
-            }
-        }
-
-        internal (string connectionProfileName, Dictionary<string, ConnectionProfile> connectionProfile, ConnectionProfile profile, ObservableCollection<string> ConnectionProfileNameHistory, ObservableCollection<Dictionary<string, ConnectionProfile>> ConnectionProfileHistory, ObservableCollection<string> CognitiveServiceKeyHistory, ObservableCollection<string> CognitiveServiceRegionHistory) Get()
+        internal (string connectionProfileName, Dictionary<string, ConnectionProfile> connectionProfile, ConnectionProfile profile, ObservableCollection<string> ConnectionProfileNameHistory, ObservableCollection<Dictionary<string, ConnectionProfile>> ConnectionProfileHistory) Get()
         {
             return (
                 this.connectionProfileName,
                 this.connectionProfile,
                 this.profile,
                 this.ConnectionProfileNameHistory,
-                this.ConnectionProfileHistory,
-                this.CognitiveServiceKeyHistory,
-                this.CognitiveServiceRegionHistory);
+                this.ConnectionProfileHistory);
         }
 
         internal void Set(
@@ -277,25 +212,19 @@ namespace VoiceAssistantClient.Settings
             Dictionary<string, ConnectionProfile> connectionProfile,
             ConnectionProfile profile,
             ObservableCollection<string> connectionProfileNameHistory,
-            ObservableCollection<Dictionary<string, ConnectionProfile>> connectionProfileHistory,
-            ObservableCollection<string> cognitiveServiceKeyHistory,
-            ObservableCollection<string> cognitiveServiceRegionHistory)
+            ObservableCollection<Dictionary<string, ConnectionProfile>> connectionProfileHistory)
         {
             (this.connectionProfileName,
                 this.connectionProfile,
                 this.profile,
                 this.connectionProfileNameHistory,
-                this.connectionProfileHistory,
-                this.cognitiveServiceKeyHistory,
-                this.cognitiveServiceRegionHistory)
+                this.connectionProfileHistory)
                 =
             (connectionProfileName,
                 connectionProfile,
                 profile,
                 this.ConnectionProfileNameHistory,
-                this.ConnectionProfileHistory,
-                this.CognitiveServiceKeyHistory,
-                this.CognitiveServiceRegionHistory);
+                this.ConnectionProfileHistory);
         }
 
         protected void SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
@@ -320,21 +249,6 @@ namespace VoiceAssistantClient.Settings
         private void ConnectionProfileHistory_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             this.OnPropertyChanged(nameof(this.ConnectionProfileHistory));
-        }
-
-        private void CognitiveServiceKeyHistory_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            this.OnPropertyChanged(nameof(this.CognitiveServiceKeyHistory));
-        }
-
-        private void CognitiveServiceRegionHistory_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            this.OnPropertyChanged(nameof(this.CognitiveServiceRegionHistory));
-        }
-
-        private void CustomCommandsAppIdHistory_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            this.OnPropertyChanged(nameof(this.CustomCommandsAppIdHistory));
         }
     }
 }

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Settings" MinHeight="700" Height="700" Width="600" MinWidth="500" >
+        Title="Settings" MinHeight="700" Height="700" Width="615" MinWidth="500" >
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">
             <Setter Property="Margin" Value="0,2"/>
@@ -53,13 +53,13 @@
                 <Label  Grid.Row="0" Grid.Column="0" Content="General settings:" FontWeight="Bold" />
 
                 <Label Grid.Row="1" Grid.Column="0" Content="Subscription key:"/>
-                <ComboBox Grid.Row="1" Grid.Column="1" Name="SubscriptionKeyComboBox" IsEditable="True"  Padding="5" TextBoxBase.TextChanged="SubscriptionKeyTextBox_TextChanged"  Text="{Binding SubscriptionKey}"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Name="SubscriptionKeyTextBox" TextBoxBase.TextChanged="SubscriptionKeyTextBox_TextChanged"  Text="{Binding SubscriptionKey}"/>
 
                 <Label  Grid.Row="2" Grid.Column="0" Content="Subscription key region:"/>
-                <ComboBox  Grid.Row="2" Grid.Column="1" Name='SubscriptionRegionComboBox'  IsEditable="True" TextBoxBase.TextChanged="SubscriptionKeyRegionTextBox_TextChanged" Text="{Binding SubscriptionKeyRegion}"/>
+                <TextBox  Grid.Row="2" Grid.Column="1" Name='SubscriptionRegionTextBox' TextBoxBase.TextChanged="SubscriptionKeyRegionTextBox_TextChanged" Text="{Binding SubscriptionKeyRegion}"/>
 
                 <Label Grid.Row="3" Grid.Column="0" Content="Custom commands app Id:"/>
-                <ComboBox Grid.Row="3" Grid.Column="1" Name="CustomCommandsAppIdComboBox" IsEditable="True"  Padding="5" TextBoxBase.TextChanged="CustomCommandsAppIdTextBox_TextChanged"  Text="{Binding CustomCommandsAppId}"/>
+                <TextBox Grid.Row="3" Grid.Column="1" Name="CustomCommandsAppIdTextBox" TextBoxBase.TextChanged="CustomCommandsAppIdTextBox_TextChanged"  Text="{Binding CustomCommandsAppId}"/>
 
                 <Label Grid.Row="4" Grid.Column="0" Content="Bot Id:"/>
                 <TextBox Grid.Row="4" Grid.Column="1" Name="BotIdTextBox" Text="{Binding BotId}"/>
@@ -166,6 +166,7 @@
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
             <TextBlock Name="SaveButtonInfoBlock" Text="" Foreground="Red" Margin="0,0,10,0"/>
             <Button Name="SaveButton"     Content="Save Profile" Width="auto" Padding="8,0,8,0" Margin="5,0" Click="SaveButton_Click"/>
+            <Button Name="DeleteProfile" Content="Delete Profile" Width="auto" Padding="8,0,8,0" Margin="5,0" Click="DeleteProfile_Click"/>
             <Button Name="CancelButton" Content="Discard Profile Changes" IsCancel="True" Width="auto" Padding="8,0,8,0" Margin="5,0" Click="CancelButton_Click"/>
         </StackPanel>
     </Grid>

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -33,9 +33,7 @@ namespace VoiceAssistantClient
                 this.ConnectionProfile,
                 this.settings.Profile,
                 this.settings.ConnectionProfileNameHistory,
-                this.settings.ConnectionProfileHistory,
-                this.settings.CognitiveServiceKeyHistory,
-                this.settings.CognitiveServiceRegionHistory) = settings.Get();
+                this.settings.ConnectionProfileHistory) = settings.Get();
 
             this.CustomSpeechConfig = new CustomSpeechConfiguration(settings.CustomSpeechEndpointId);
             this.VoiceDeploymentConfig = new VoiceDeploymentConfiguration(settings.VoiceDeploymentIds);
@@ -105,12 +103,9 @@ namespace VoiceAssistantClient
         {
             this.ConnectionProfileComboBox.ItemsSource = this.settings.ConnectionProfileNameHistory;
             this.ConnectionProfileComboBox.Text = this.ConnectionProfileName;
-            this.SubscriptionKeyComboBox.ItemsSource = this.settings.CognitiveServiceKeyHistory;
-            this.SubscriptionKeyComboBox.Text = this.settings.Profile.SubscriptionKey;
-            this.SubscriptionRegionComboBox.ItemsSource = this.settings.CognitiveServiceRegionHistory;
-            this.SubscriptionRegionComboBox.Text = this.settings.Profile.SubscriptionKeyRegion;
-            this.CustomCommandsAppIdComboBox.ItemsSource = this.settings.CustomCommandsAppIdHistory;
-            this.CustomCommandsAppIdComboBox.Text = this.settings.Profile.CustomCommandsAppId;
+            this.SubscriptionKeyTextBox.Text = this.settings.Profile.SubscriptionKey;
+            this.SubscriptionRegionTextBox.Text = this.settings.Profile.SubscriptionKeyRegion;
+            this.CustomCommandsAppIdTextBox.Text = this.settings.Profile.CustomCommandsAppId;
             this.BotIdTextBox.Text = this.settings.Profile.BotId;
             this.LanguageTextBox.Text = this.settings.Profile.ConnectionLanguage;
             this.LogFileTextBox.Text = this.settings.Profile.LogFilePath;
@@ -131,9 +126,9 @@ namespace VoiceAssistantClient
         protected override void OnDeactivated(EventArgs e)
         {
             this.ConnectionProfileName = this.ConnectionProfileComboBox.Text;
-            this.settings.Profile.SubscriptionKey = this.SubscriptionKeyComboBox.Text;
-            this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
-            this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+            this.settings.Profile.SubscriptionKey = this.SubscriptionKeyTextBox.Text;
+            this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionTextBox.Text;
+            this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdTextBox.Text;
             this.settings.Profile.BotId = this.BotIdTextBox.Text;
             this.settings.Profile.ConnectionLanguage = this.LanguageTextBox.Text;
             this.settings.Profile.LogFilePath = this.LogFileTextBox.Text;
@@ -157,9 +152,9 @@ namespace VoiceAssistantClient
             {
                 if (this.ConnectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text))
                 {
-                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey = this.SubscriptionKeyComboBox.Text;
-                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
-                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey = this.SubscriptionKeyTextBox.Text;
+                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion = this.SubscriptionRegionTextBox.Text;
+                    this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId = this.CustomCommandsAppIdTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].BotId = this.BotIdTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].ConnectionLanguage = this.LanguageTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].LogFilePath = this.LogFileTextBox.Text;
@@ -176,9 +171,9 @@ namespace VoiceAssistantClient
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath = this.WakeWordPathTextBox.Text;
                     this.ConnectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled = (bool)this.WakeWordEnabledBox.IsChecked;
 
-                    this.settings.Profile.SubscriptionKey = this.SubscriptionKeyComboBox.Text;
-                    this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
-                    this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+                    this.settings.Profile.SubscriptionKey = this.SubscriptionKeyTextBox.Text;
+                    this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionTextBox.Text;
+                    this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdTextBox.Text;
                     this.settings.Profile.BotId = this.BotIdTextBox.Text;
                     this.settings.Profile.ConnectionLanguage = this.LanguageTextBox.Text;
                     this.settings.Profile.LogFilePath = this.LogFileTextBox.Text;
@@ -221,21 +216,26 @@ namespace VoiceAssistantClient
 
                 this.AddConnectionProfileNameIntoHistory(this.ConnectionProfileName);
                 this.AddConnectionProfileIntoHistory(this.ConnectionProfile);
-                this.AddCognitiveServicesKeyEntryIntoHistory(this.SubscriptionKey);
-                this.AddCognitiveServicesRegionEntryIntoHistory(this.SubscriptionKeyRegion);
-                this.AddCustomCommandsAppIdEntryIntoHistory(this.CustomCommandsAppId);
                 this.settings.Set(
                     this.ConnectionProfileName,
                     this.ConnectionProfile,
                     this.settings.Profile,
                     this.settings.ConnectionProfileNameHistory,
-                    this.settings.ConnectionProfileHistory,
-                    this.settings.CognitiveServiceKeyHistory,
-                    this.settings.CognitiveServiceRegionHistory);
+                    this.settings.ConnectionProfileHistory);
             }
 
             this.DialogResult = true;
             this.Close();
+        }
+
+        private void DeleteProfile_Click(object sender, RoutedEventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(this.ConnectionProfileComboBox.Text))
+            {
+                this.ConnectionProfile.Remove(this.ConnectionProfileComboBox.Text);
+                this.settings.ConnectionProfileNameHistory.Remove(this.ConnectionProfileComboBox.Text);
+                this.ConnectionProfileComboBox.Text = string.Empty;
+            }
         }
 
         private void AddConnectionProfileNameIntoHistory(string connectionProfileName)
@@ -273,54 +273,6 @@ namespace VoiceAssistantClient
                             }
                         }
                     }
-                }
-            }
-        }
-
-        private void AddCognitiveServicesKeyEntryIntoHistory(string cognitiveServicesKey)
-        {
-            var keyHistory = this.settings.CognitiveServiceKeyHistory;
-
-            var existingItem = keyHistory.FirstOrDefault(item => string.Compare(item, cognitiveServicesKey, StringComparison.OrdinalIgnoreCase) == 0);
-
-            if (existingItem == null)
-            {
-                keyHistory.Insert(0, cognitiveServicesKey);
-                if (keyHistory.Count == UrlHistoryMaxLength)
-                {
-                    keyHistory.RemoveAt(UrlHistoryMaxLength - 1);
-                }
-            }
-        }
-
-        private void AddCognitiveServicesRegionEntryIntoHistory(string cognitiveServicesKey)
-        {
-            var regionHistory = this.settings.CognitiveServiceRegionHistory;
-
-            var existingItem = regionHistory.FirstOrDefault(item => string.Compare(item, cognitiveServicesKey, StringComparison.OrdinalIgnoreCase) == 0);
-
-            if (existingItem == null)
-            {
-                regionHistory.Insert(0, cognitiveServicesKey);
-                if (regionHistory.Count == UrlHistoryMaxLength)
-                {
-                    regionHistory.RemoveAt(UrlHistoryMaxLength - 1);
-                }
-            }
-        }
-
-        private void AddCustomCommandsAppIdEntryIntoHistory(string customCommandsAppId)
-        {
-            var idHistory = this.settings.CustomCommandsAppIdHistory;
-
-            var existingItem = idHistory.FirstOrDefault(item => string.Compare(item, customCommandsAppId, StringComparison.OrdinalIgnoreCase) == 0);
-
-            if (existingItem == null)
-            {
-                idHistory.Insert(0, customCommandsAppId);
-                if (idHistory.Count == UrlHistoryMaxLength)
-                {
-                    idHistory.RemoveAt(UrlHistoryMaxLength - 1);
                 }
             }
         }
@@ -371,11 +323,12 @@ namespace VoiceAssistantClient
         {
             // BUGBUG: The transfer into variables does not seem to be done consistently with these events so we read straight from the controls
             var hasConnectionProfileName = !string.IsNullOrWhiteSpace(this.ConnectionProfileComboBox.Text);
-            var hasSubscription = !string.IsNullOrWhiteSpace(this.SubscriptionKeyComboBox.Text);
-            var hasRegion = !string.IsNullOrWhiteSpace(this.SubscriptionRegionComboBox.Text);
+            var hasSubscription = !string.IsNullOrWhiteSpace(this.SubscriptionKeyTextBox.Text);
+            var hasRegion = !string.IsNullOrWhiteSpace(this.SubscriptionRegionTextBox.Text);
             var hasUrlOverride = !string.IsNullOrWhiteSpace(this.UrlOverrideTextBox.Text);
 
             var enableSaveButton = false;
+            var enableDeleteButton = false;
             if (!hasConnectionProfileName)
             {
                 this.SaveButtonInfoBlock.Text = "You must provide a profile name";
@@ -396,9 +349,12 @@ namespace VoiceAssistantClient
             {
                 this.SaveButtonInfoBlock.Text = string.Empty;
                 enableSaveButton = true;
+                enableDeleteButton = true;
+
             }
 
             this.SaveButton.IsEnabled = enableSaveButton;
+            this.DeleteProfile.IsEnabled = enableDeleteButton;
         }
 
         private void CustomSpeechEnabledBox_Checked(object sender, RoutedEventArgs e)
@@ -559,9 +515,9 @@ namespace VoiceAssistantClient
             {
                 if (this.ConnectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text))
                 {
-                    this.SubscriptionKeyComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey;
-                    this.SubscriptionRegionComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion;
-                    this.CustomCommandsAppIdComboBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId;
+                    this.SubscriptionKeyTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey;
+                    this.SubscriptionRegionTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion;
+                    this.CustomCommandsAppIdTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId;
                     this.BotIdTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].BotId;
                     this.LanguageTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].ConnectionLanguage;
                     this.LogFileTextBox.Text = this.ConnectionProfile[this.ConnectionProfileComboBox.Text].LogFilePath;
@@ -578,9 +534,9 @@ namespace VoiceAssistantClient
                 }
                 else
                 {
-                    this.SubscriptionKeyComboBox.Text = string.Empty;
-                    this.SubscriptionRegionComboBox.Text = string.Empty;
-                    this.CustomCommandsAppIdComboBox.Text = string.Empty;
+                    this.SubscriptionKeyTextBox.Text = string.Empty;
+                    this.SubscriptionRegionTextBox.Text = string.Empty;
+                    this.CustomCommandsAppIdTextBox.Text = string.Empty;
                     this.BotIdTextBox.Text = string.Empty;
                     this.LanguageTextBox.Text = string.Empty;
                     this.LogFileTextBox.Text = string.Empty;

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -111,7 +111,44 @@ namespace VoiceAssistantClient
             this.SubscriptionRegionComboBox.Text = this.settings.Profile.SubscriptionKeyRegion;
             this.CustomCommandsAppIdComboBox.ItemsSource = this.settings.CustomCommandsAppIdHistory;
             this.CustomCommandsAppIdComboBox.Text = this.settings.Profile.CustomCommandsAppId;
+            this.BotIdTextBox.Text = this.settings.Profile.BotId;
+            this.LanguageTextBox.Text = this.settings.Profile.ConnectionLanguage;
+            this.LogFileTextBox.Text = this.settings.Profile.LogFilePath;
+            this.UrlOverrideTextBox.Text = this.settings.Profile.UrlOverride;
+            this.ProxyHost.Text = this.settings.Profile.ProxyHostName;
+            this.ProxyPort.Text = this.settings.Profile.ProxyPortNumber;
+            this.FromIdTextBox.Text = this.settings.Profile.FromId;
+            this.WakeWordPathTextBox.Text = this.settings.Profile.WakeWordPath;
+            this.WakeWordEnabledBox.IsChecked = this.settings.Profile.WakeWordEnabled;
+            this.CustomSpeechEndpointIdTextBox.Text = this.settings.Profile.CustomSpeechEndpointId;
+            this.CustomSpeechEnabledBox.IsChecked = this.settings.Profile.CustomSpeechEnabled;
+            this.VoiceDeploymentIdsTextBox.Text = this.settings.Profile.VoiceDeploymentIds;
+            this.VoiceDeploymentEnabledBox.IsChecked = this.settings.Profile.VoiceDeploymentEnabled;
+
             base.OnActivated(e);
+        }
+
+        protected override void OnDeactivated(EventArgs e)
+        {
+            this.ConnectionProfileName = this.ConnectionProfileComboBox.Text;
+            this.settings.Profile.SubscriptionKey = this.SubscriptionKeyComboBox.Text;
+            this.settings.Profile.SubscriptionKeyRegion = this.SubscriptionRegionComboBox.Text;
+            this.settings.Profile.CustomCommandsAppId = this.CustomCommandsAppIdComboBox.Text;
+            this.settings.Profile.BotId = this.BotIdTextBox.Text;
+            this.settings.Profile.ConnectionLanguage = this.LanguageTextBox.Text;
+            this.settings.Profile.LogFilePath = this.LogFileTextBox.Text;
+            this.settings.Profile.UrlOverride = this.UrlOverrideTextBox.Text;
+            this.settings.Profile.ProxyHostName = this.ProxyHost.Text;
+            this.settings.Profile.ProxyPortNumber = this.ProxyPort.Text;
+            this.settings.Profile.FromId = this.FromIdTextBox.Text;
+            this.settings.Profile.WakeWordPath = this.WakeWordPathTextBox.Text;
+            this.settings.Profile.WakeWordEnabled = (bool)this.WakeWordEnabledBox.IsChecked;
+            this.settings.Profile.CustomSpeechEndpointId = this.CustomSpeechEndpointIdTextBox.Text;
+            this.settings.Profile.CustomSpeechEnabled = (bool)this.CustomSpeechEnabledBox.IsChecked;
+            this.settings.Profile.VoiceDeploymentIds = this.VoiceDeploymentIdsTextBox.Text;
+            this.settings.Profile.VoiceDeploymentEnabled = (bool)this.VoiceDeploymentEnabledBox.IsChecked;
+
+            base.OnDeactivated(e);
         }
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)

--- a/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
+++ b/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
@@ -110,17 +110,17 @@
     <Reference Include="Jot, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Jot.1.4.1\lib\net45\Jot.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Schema, Version=4.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Schema.4.7.2\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Schema, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Schema.4.8.0\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CognitiveServices.Speech.csharp, Version=1.10.0.28, Culture=neutral, PublicKeyToken=d2e6dcccb609e663, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CognitiveServices.Speech.1.10.0\lib\net461\Microsoft.CognitiveServices.Speech.csharp.dll</HintPath>
+    <Reference Include="Microsoft.CognitiveServices.Speech.csharp, Version=1.11.0.28, Culture=neutral, PublicKeyToken=d2e6dcccb609e663, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CognitiveServices.Speech.1.11.0\lib\net461\Microsoft.CognitiveServices.Speech.csharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.MarkedNet, Version=1.0.13.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.MarkedNet.1.0.13\lib\net452\Microsoft.MarkedNet.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.9.0\lib\net35\NAudio.dll</HintPath>
+    <Reference Include="NAudio, Version=1.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.10.0\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -141,20 +141,20 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.7.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.7.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.7.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.7.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.Toolkit, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.7.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -304,13 +304,13 @@
     <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CognitiveServices.Speech.1.10.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CognitiveServices.Speech.1.10.0\build\net461\Microsoft.CognitiveServices.Speech.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CognitiveServices.Speech.1.11.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CognitiveServices.Speech.1.11.0\build\net461\Microsoft.CognitiveServices.Speech.targets'))" />
   </Target>
   <Import Project="..\packages\SourceLink.Create.CommandLine.2.8.3\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\packages\SourceLink.Create.CommandLine.2.8.3\build\SourceLink.Create.CommandLine.targets')" />
-  <Import Project="..\packages\Microsoft.CognitiveServices.Speech.1.10.0\build\net461\Microsoft.CognitiveServices.Speech.targets" Condition="Exists('..\packages\Microsoft.CognitiveServices.Speech.1.10.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" />
   <PropertyGroup>
     <PostBuildEvent>rem This is a workaround to fix the issue https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/issues/150.
 rem Since Microsoft.CognitiveServices.Speech version number is part of the source path, the source path should be updated when upgrading Microsoft.CognitiveServices.Speech.
-copy $(SolutionDir)\packages\Microsoft.CognitiveServices.Speech.1.10.0\runtimes\win-$(PlatformName)\native\Microsoft.CognitiveServices.Speech.core.dll $(TargetDir)</PostBuildEvent>
+copy $(SolutionDir)\packages\Microsoft.CognitiveServices.Speech.1.11.0\runtimes\win-$(PlatformName)\native\Microsoft.CognitiveServices.Speech.core.dll $(TargetDir)</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Microsoft.CognitiveServices.Speech.1.11.0\build\net461\Microsoft.CognitiveServices.Speech.targets" Condition="Exists('..\packages\Microsoft.CognitiveServices.Speech.1.11.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" />
 </Project>

--- a/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
+++ b/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
@@ -113,9 +113,6 @@
     <Reference Include="Microsoft.Bot.Schema, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Schema.4.8.0\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Build.Framework.16.5.0\lib\netstandard2.0\Microsoft.Build.Framework.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CognitiveServices.Speech.csharp, Version=1.11.0.28, Culture=neutral, PublicKeyToken=d2e6dcccb609e663, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CognitiveServices.Speech.1.11.0\lib\net461\Microsoft.CognitiveServices.Speech.csharp.dll</HintPath>
     </Reference>

--- a/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
+++ b/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
@@ -113,6 +113,9 @@
     <Reference Include="Microsoft.Bot.Schema, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Schema.4.8.0\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.Framework.16.5.0\lib\netstandard2.0\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CognitiveServices.Speech.csharp, Version=1.11.0.28, Culture=neutral, PublicKeyToken=d2e6dcccb609e663, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CognitiveServices.Speech.1.11.0\lib\net461\Microsoft.CognitiveServices.Speech.csharp.dll</HintPath>
     </Reference>
@@ -127,6 +130,17 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Presentation" />
     <Reference Include="System.Xml" />

--- a/clients/csharp-wpf/VoiceAssistantClient/packages.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/packages.config
@@ -6,7 +6,6 @@
   <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net461" />
   <package id="Jot" version="1.4.1" targetFramework="net461" />
   <package id="Microsoft.Bot.Schema" version="4.8.0" targetFramework="net461" />
-  <package id="Microsoft.Build.Framework" version="16.5.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />

--- a/clients/csharp-wpf/VoiceAssistantClient/packages.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/packages.config
@@ -3,18 +3,18 @@
   <package id="AdaptiveCards" version="1.2.4" targetFramework="net461" />
   <package id="AdaptiveCards.Rendering.Wpf" version="1.2.4" targetFramework="net461" />
   <package id="AdaptiveCards.Rendering.Wpf.Xceed" version="1.2.4" targetFramework="net461" />
-  <package id="Extended.Wpf.Toolkit" version="3.7.0" targetFramework="net461" />
+  <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net461" />
   <package id="Jot" version="1.4.1" targetFramework="net461" />
-  <package id="Microsoft.Bot.Schema" version="4.7.2" targetFramework="net461" />
+  <package id="Microsoft.Bot.Schema" version="4.8.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.CognitiveServices.Speech" version="1.10.0" targetFramework="net461" />
+  <package id="Microsoft.CognitiveServices.Speech" version="1.11.0" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
   <package id="Microsoft.MarkedNet" version="1.0.13" targetFramework="net461" />
   <package id="Microsoft.NetCore.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="NAudio" version="1.9.0" targetFramework="net461" />
+  <package id="NAudio" version="1.10.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="SourceLink.Create.CommandLine" version="2.8.3" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.113" targetFramework="net461" developmentDependency="true" />

--- a/clients/csharp-wpf/VoiceAssistantClient/packages.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/packages.config
@@ -6,6 +6,7 @@
   <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net461" />
   <package id="Jot" version="1.4.1" targetFramework="net461" />
   <package id="Microsoft.Bot.Schema" version="4.8.0" targetFramework="net461" />
+  <package id="Microsoft.Build.Framework" version="16.5.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
@@ -19,4 +20,6 @@
   <package id="SourceLink.Create.CommandLine" version="2.8.3" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.113" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.113" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
## Purpose
* Previously the app was losing scope when deactivated (switching to another app) - text fields were reverting back to the original text from previous profile. This fix is to ensure that the values entered in the respective fields are not lost when application is deactivated. 
* Combo boxes with previous history of Subscription Key, Region, and Custom Commands App Id have been replaced with Text Boxes.
* Delete Profile button has been added to remove a profile and its associated values from app history. 

## Does this introduce a breaking change?
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Create a new profile
* Copy and paste the values being tested - Text fields should keep the values pasted
* Connect to Bot
* Create a new profile, save profile, open settings and delete the created profile.
  * Upon clicking delete, all populated fields along with the profile name will become empty and deleted profile will be removed from the Profile History list.