### PR TITLE
Fix for persistent values on discard changes

### DIFF
--- a/clients/csharp-wpf/README.md
+++ b/clients/csharp-wpf/README.md
@@ -102,9 +102,7 @@ Here is an example of how to send a message back:
 
     var botFrameworkActivity = Activity.CreateMessageActivity();
     botFrameworkActivity.Text = submitAction.Data.ToString();
-    if (!string.IsNullOrEmpty(
-    
-    FromId))
+    if (!string.IsNullOrEmpty(FromId))
     {
         botFrameworkActivity.From = new ChannelAccount(this.settings.RuntimeSettings.Profile.FromId);
     }

--- a/clients/csharp-wpf/README.md
+++ b/clients/csharp-wpf/README.md
@@ -102,9 +102,11 @@ Here is an example of how to send a message back:
 
     var botFrameworkActivity = Activity.CreateMessageActivity();
     botFrameworkActivity.Text = submitAction.Data.ToString();
-    if (!string.IsNullOrEmpty(this.settings.RuntimeSettings.FromId))
+    if (!string.IsNullOrEmpty(
+    
+    FromId))
     {
-        botFrameworkActivity.From = new ChannelAccount(this.settings.RuntimeSettings.FromId);
+        botFrameworkActivity.From = new ChannelAccount(this.settings.RuntimeSettings.Profile.FromId);
     }
 
     var jsonConnectorActivity = JsonConvert.SerializeObject(botFrameworkActivity);

--- a/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -252,7 +252,7 @@ namespace VoiceAssistantClient
                 // from.id field identifies who generated the activity, and may be required by some bots.
                 // See https://github.com/microsoft/botframework-sdk/blob/master/specs/botframework-activity/botframework-activity.md
                 // for Bot Framework Activity schema and from.id.
-                config.SetProperty(PropertyId.Conversation_From_Id, this.settings.RuntimeSettings.FromId);
+                config.SetProperty(PropertyId.Conversation_From_Id, this.settings.RuntimeSettings.Profile.FromId);
             }
 
             if (!string.IsNullOrWhiteSpace(this.settings.RuntimeSettings.Profile.LogFilePath))

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Settings" MinHeight="700" Height="700" Width="675" MinWidth="500" >
+        Title="Settings" MinHeight="700" Height="700" Width="675" MinWidth="675" 
+        WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">
             <Setter Property="Margin" Value="0,2"/>

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -48,7 +48,7 @@ namespace VoiceAssistantClient
 
         protected override void OnContentRendered(EventArgs e)
         {
-            this.WakeWordPathTextBox.Text = this.settings.WakeWordPath ?? string.Empty;
+            this.WakeWordPathTextBox.Text = this.settings.Profile.WakeWordPath ?? string.Empty;
             this.UpdateSaveButtonState();
             this.UpdateCustomSpeechStatus(false);
             this.UpdateVoiceDeploymentIdsStatus(false);
@@ -225,6 +225,26 @@ namespace VoiceAssistantClient
 
         private void CancelButton_Click(object sender, RoutedEventArgs e)
         {
+            if (this.connectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text))
+            {
+                this.SubscriptionKeyTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKey;
+                this.SubscriptionRegionTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].SubscriptionKeyRegion;
+                this.CustomCommandsAppIdTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].CustomCommandsAppId;
+                this.BotIdTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].BotId;
+                this.LanguageTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].ConnectionLanguage;
+                this.LogFileTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].LogFilePath;
+                this.UrlOverrideTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].UrlOverride;
+                this.ProxyHost.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].ProxyHostName;
+                this.ProxyPort.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].ProxyPortNumber;
+                this.FromIdTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].FromId;
+                this.CustomSpeechEndpointIdTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].CustomSpeechEndpointId;
+                this.CustomSpeechEnabledBox.IsChecked = this.connectionProfile[this.ConnectionProfileComboBox.Text].CustomSpeechEnabled;
+                this.VoiceDeploymentIdsTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentIds;
+                this.VoiceDeploymentEnabledBox.IsChecked = this.connectionProfile[this.ConnectionProfileComboBox.Text].VoiceDeploymentEnabled;
+                this.WakeWordPathTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath;
+                this.WakeWordEnabledBox.IsChecked = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled;
+            }
+
             this.DialogResult = false;
             this.Close();
         }
@@ -268,7 +288,7 @@ namespace VoiceAssistantClient
         private void UpdateSaveButtonState()
         {
             // BUGBUG: The transfer into variables does not seem to be done consistently with these events so we read straight from the controls
-            var hasConnectionProfileName = !string.IsNullOrWhiteSpace(this.ConnectionProfileComboBox.Text);
+            var hasConnectionProfileName = !string.IsNullOrWhiteSpace(this.ConnectionProfileComboBox.Text) && this.ConnectionProfileComboBox.Text != " ";
             var hasSubscription = !string.IsNullOrWhiteSpace(this.SubscriptionKeyTextBox.Text);
             var hasRegion = !string.IsNullOrWhiteSpace(this.SubscriptionRegionTextBox.Text);
             var hasUrlOverride = !string.IsNullOrWhiteSpace(this.UrlOverrideTextBox.Text);

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -78,8 +78,8 @@ namespace VoiceAssistantClient
             this.CustomSpeechEnabledBox.IsChecked = this.settings.Profile.CustomSpeechEnabled;
             this.VoiceDeploymentIdsTextBox.Text = this.settings.Profile.VoiceDeploymentIds;
             this.VoiceDeploymentEnabledBox.IsChecked = this.settings.Profile.VoiceDeploymentEnabled;
-
-            if (!this.connectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text))
+            
+            if (this.settings.ConnectionProfileNameHistory.Count == 1)
             {
                 this.ConnectionProfileComboBox.Text = string.Empty;
             }

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -246,6 +246,7 @@ namespace VoiceAssistantClient
             }
             else
             {
+                this.ConnectionProfileComboBox.Text = string.Empty;
                 this.SetConnectionSettingsTextBoxesToEmpty();
             }
 

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -244,6 +244,10 @@ namespace VoiceAssistantClient
                 this.WakeWordPathTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath;
                 this.WakeWordEnabledBox.IsChecked = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled;
             }
+            else
+            {
+                this.SetConnectionSettingsTextBoxesToEmpty();
+            }
 
             this.DialogResult = false;
             this.Close();
@@ -502,6 +506,8 @@ namespace VoiceAssistantClient
                     this.SetConnectionSettingsTextBoxesToEmpty();
                 }
             }
+
+            this.UpdateSaveButtonState();
         }
 
         private void SetConnectionSettingsTextBoxesToEmpty()

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -79,6 +79,11 @@ namespace VoiceAssistantClient
             this.VoiceDeploymentIdsTextBox.Text = this.settings.Profile.VoiceDeploymentIds;
             this.VoiceDeploymentEnabledBox.IsChecked = this.settings.Profile.VoiceDeploymentEnabled;
 
+            if (!this.connectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text))
+            {
+                this.ConnectionProfileComboBox.Text = string.Empty;
+            }
+
             base.OnActivated(e);
         }
 
@@ -247,6 +252,7 @@ namespace VoiceAssistantClient
             else
             {
                 this.ConnectionProfileComboBox.Text = string.Empty;
+                this.ConnectionProfileName = string.Empty;
                 this.SetConnectionSettingsTextBoxesToEmpty();
             }
 


### PR DESCRIPTION
## Purpose
* This PR address multiple issues
* On discard changes, modified profile settings persisted on next activation. *Fix* - modification to a profile's settings will not stay in focus. A profiles saved values will be used if changes are discarded. 
* FromId, and LanguageId were not mapped correctly.
* Settings Dialog opened at random positions - *Fix*: now opens at the center of the main window
* If all profiles are deleted, the last deleted profile name was persisting on next application launch - *Fix* : If all profiles are deleted, ConnectionProfileComboBox.Text will be empty
* UpdateState was now being called when ConnectionProfileComboBox Text changed. This prevented the indication that a profile name is required to proceed- *Fix*: If profile name is empty red textblock will show indicating above is a required field
* WakeWordPath was not shown on settings activation. Previously if the a WakeWordPath was entered, its value was hidden when the settings dialog was activated - *Fix*: WakeWordPath persists on activation and deactivation

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
* Create Profile 1 enter xxx for Subscription Key and Azure Region
* Save Profile 1
* Create Profile 2 enter yyy for Subscription Key and Azure Region
* Save Profile 2
* Select Profile 1 and change the "xxx" to iii
* Discard Changes
* Open settings and select Profile 1 - its Subscription Key and Region should be xxx
* Add a wakeword path to the above steps to test its persistence
