### PR TITLE
Discard unsaved profile

### DIFF
--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -271,7 +271,7 @@ namespace VoiceAssistantClient
             else
             {
                 this.ConnectionProfileComboBox.Text = string.Empty;
-                this.ConnectionProfileName = string.Empty;
+                this.settings.ConnectionProfileName = string.Empty;
                 this.SetConnectionSettingsTextBoxesToEmpty();
             }
 

--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml.cs
@@ -249,6 +249,25 @@ namespace VoiceAssistantClient
                 this.WakeWordPathTextBox.Text = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordPath;
                 this.WakeWordEnabledBox.IsChecked = this.connectionProfile[this.ConnectionProfileComboBox.Text].WakeWordEnabled;
             }
+            else if (!this.connectionProfile.ContainsKey(this.ConnectionProfileComboBox.Text) && this.settings.ConnectionProfileNameHistory.Count > 1)
+            {
+                this.SubscriptionKeyTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].SubscriptionKey;
+                this.SubscriptionRegionTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].SubscriptionKeyRegion;
+                this.CustomCommandsAppIdTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].CustomCommandsAppId;
+                this.BotIdTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].BotId;
+                this.LanguageTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].ConnectionLanguage;
+                this.LogFileTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].LogFilePath;
+                this.UrlOverrideTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].UrlOverride;
+                this.ProxyHost.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].ProxyHostName;
+                this.ProxyPort.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].ProxyPortNumber;
+                this.FromIdTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].FromId;
+                this.CustomSpeechEndpointIdTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].CustomSpeechEndpointId;
+                this.CustomSpeechEnabledBox.IsChecked = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].CustomSpeechEnabled;
+                this.VoiceDeploymentIdsTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].VoiceDeploymentIds;
+                this.VoiceDeploymentEnabledBox.IsChecked = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].VoiceDeploymentEnabled;
+                this.WakeWordPathTextBox.Text = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].WakeWordPath;
+                this.WakeWordEnabledBox.IsChecked = this.connectionProfile[this.settings.ConnectionProfileNameHistory[1]].WakeWordEnabled;
+            }
             else
             {
                 this.ConnectionProfileComboBox.Text = string.Empty;


### PR DESCRIPTION
## Purpose
* Saved profile's settings were not shown on Settings Dialog Activation when unsaved profile was discarded. 
* If all profiles are deleted, the last profile's name lingered in the ConnectionProfileComboBox

* Fixed the above two issues.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
1. Create Profile 1
2. Enter 111 for Subscription Key and Region
3. Save Profile
4. Open the Settings Dialog and enter Profile 2 in the Connection Profile dropdown
5. Discard Changes
6. Open the Settings Dialog - Profile 1 and its associated value should be seen
7. Repeat steps 1 - 3 with different profile names - create two additional profiles.
8. Delete all created profiles and click the x button or discard changes
9. Open the Settings Dialog - the Connection Profile should be blank and the last deleted profile's name should not be seen. 