### PR TITLE
Switch to using self-hosted build agent on Windows Insiders machine, and add UWP sample to the build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,12 +17,13 @@ pr:
   branches:
     include:
     - master
-    
-pool:
-  vmImage: 'windows-latest'
 
-# Use this when build agents are ready:
-# pool: 'Voice Assistant Agent Pool'
+# Use this for Microsoft-hosted build agents (released versions of Windows only):    
+#pool:
+#  vmImage: 'windows-latest'
+
+# Use this for self-hosted build agents, when you need to build on a pre-release version of Windows: 
+pool: 'Voice Assistant Agent Pool'
 
 
 variables:
@@ -101,7 +102,7 @@ variables:
           "toolVersion": "6.2.9304.0"
        }
     ]
-
+    
 steps:
 
 - task: NuGetToolInstaller@1
@@ -172,24 +173,24 @@ steps:
 
 # Build UWP Voice Assistant Sample (C# UWP)
 
-#- task: NuGetCommand@2
-#  displayName: '$(sample4Name) - NuGetCommand'
-#  inputs:
-#    restoreSolution: '$(sample4Solution)'
+- task: NuGetCommand@2
+  displayName: '$(sample4Name) - NuGetCommand'
+  inputs:
+    restoreSolution: '$(sample4Solution)'
 
-#- task: VSBuild@1
-#  displayName: '$(sample4Name) - VSBuild'
-#  inputs:
-#    solution: '$(sample4Solution)'
-#    msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
-#    platform: '$(buildPlatformNative)'
-#    configuration: '$(buildConfiguration)'
+- task: VSBuild@1
+  displayName: '$(sample4Name) - VSBuild'
+  inputs:
+    solution: '$(sample4Solution)'
+    msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatformNative)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+    platform: '$(buildPlatformNative)'
+    configuration: '$(buildConfiguration)'
 
-#- task: PublishPipelineArtifact@1
-#  displayName: '$(sample4Name) - PublishPipelineArtifact'
-#  inputs:
-#    path: $(sample4PublishedArtifactPath)
-#    artifact: $(sample4PublishedArtifactName)
+- task: PublishPipelineArtifact@1
+  displayName: '$(sample4Name) - PublishPipelineArtifact'
+  inputs:
+    path: $(sample4PublishedArtifactPath)
+    artifact: $(sample4PublishedArtifactName)
 
 #- task: VSTest@2
 #  inputs:
@@ -209,8 +210,8 @@ steps:
     targetArgument: '$(Build.SourcesDirectory)'
     result: 'PoliCheck.xml'
 
+# This does not work on self-hosted agent for some reason
 - task: notice@0
   inputs:
     outputformat: 'text'
-
 


### PR DESCRIPTION
## Purpose
* Add UWP Voice Assistant sample to the Azure DevOps build pipeline
* Use a self-hosted build agent instead of Microsoft hosted agent. This allows us to run the builds on our pre-release versions of Windows needed for the UWP sample.
* I had to disable the Notice ADO task for now, since it fails to run on my local machine. I have an e-mail out to support team to see what I can do to fix this
* Additional minor change in the UWP Sample app to remove links to non-existing documents

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x ] Other... Please describe:
```
Update build pipeline
