### PR TITLE
Fix bug #255 by defining a state machine for KWS activation

### DIFF
--- a/clients/cpp-console/src/common/mainAudio.cpp
+++ b/clients/cpp-console/src/common/mainAudio.cpp
@@ -40,7 +40,7 @@ enum class KeywordActivationState
     Undefined, 
 
     // Configuration file did not specify a keyword mode. Keyword activation not possible on this device.
-    Disabled, 
+    NotSupported, 
 
     // Keyword model exists on the device, user selected keyword activation, but the device is currently not listening for the keyword (e.g. since TTS playback is in progress and barge-in is not supported).
     Paused,
@@ -186,7 +186,6 @@ int main(int argc, char** argv)
     // Signals that indicates the end of a listening session.
     dialogServiceConnector->SessionStopped += [&](const SessionEventArgs& event) {
         printf("SESSION STOPPED: %s ...\n", event.SessionId.c_str());
-        printf("Press ENTER to acknowledge...\n");
     };
 
     // Signal for events containing intermediate recognition results.
@@ -284,7 +283,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        keywordActivationState = KeywordActivationState::Disabled;
+        keywordActivationState = KeywordActivationState::NotSupported;
     }
 
     DeviceStatusIndicators::SetStatus(DeviceStatus::Ready);
@@ -293,7 +292,7 @@ int main(int argc, char** argv)
     {
         cout << "Commands:" << endl;
         cout << "1 [listen once]" << endl;
-        if (keywordActivationState != KeywordActivationState::Disabled)
+        if (keywordActivationState != KeywordActivationState::NotSupported)
         {
             cout << "2 [start keyword listening]" << endl;
             cout << "3 [stop keyword listening]" << endl;

--- a/clients/cpp-console/src/common/mainAudio.cpp
+++ b/clients/cpp-console/src/common/mainAudio.cpp
@@ -37,19 +37,19 @@ using namespace AudioPlayer;
 enum class KeywordActivationState
 {
     // Initial value, before reading the input configuration file.
-    Undefined, 
+    Undefined = 0, 
 
     // Configuration file did not specify a keyword mode. Keyword activation not possible on this device.
-    NotSupported, 
+    NotSupported = 1, 
 
     // Keyword model exists on the device, user selected keyword activation, but the device is currently not listening for the keyword (e.g. since TTS playback is in progress and barge-in is not supported).
-    Paused,
+    Paused = 2,
 
     // Keyword model exists on the device, user selected keyword activation and the device is currently listening for the keyword.
-    Listening,  
+    Listening = 3,  
 
     // Keyword model exists on the device but the user has selected not to listen for keyword.
-    NotListening 
+    NotListening = 4 
 };
 
 void log()
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
     
     auto StartKws = [&]()
     {
-        log_t("startKwsIfApplicable called");
+        log_t("Enter StartKws (state = ", uint32_t(keywordActivationState), ")");
 
         if (KeywordActivationState::Paused == keywordActivationState)
         {
@@ -104,11 +104,13 @@ int main(int argc, char** argv)
             keywordActivationState = KeywordActivationState::Listening;
             log_t("KWS initialized");
         }
+
+        log_t("Exit StartKws (state = ", uint32_t(keywordActivationState), ")");
     };
 
     auto PauseKws = [&]()
     {
-        log_t("PauseKws called");
+        log_t("Enter PauseKws (state = ", uint32_t(keywordActivationState), ")");
 
         if (KeywordActivationState::Listening == keywordActivationState)
         {
@@ -116,11 +118,13 @@ int main(int argc, char** argv)
             auto future = dialogServiceConnector->StopKeywordRecognitionAsync();
             keywordActivationState = KeywordActivationState::Paused;
         }
+
+        log_t("Exit PauseKws (state = ", uint32_t(keywordActivationState), ")");
     };
 
     auto StopKws = [&]()
     {
-        log_t("StopKws called");
+        log_t("Enter StopKws (state = ", uint32_t(keywordActivationState), ")");
 
         if (KeywordActivationState::Listening == keywordActivationState ||
             KeywordActivationState::Paused == keywordActivationState)
@@ -133,6 +137,8 @@ int main(int argc, char** argv)
 
             keywordActivationState = KeywordActivationState::NotListening;
         }
+
+        log_t("Exit StopKws (state = ", uint32_t(keywordActivationState), ")");
     };
     
     DeviceStatusIndicators::SetStatus(DeviceStatus::Initializing);

--- a/clients/cpp-console/src/common/mainAudio.cpp
+++ b/clients/cpp-console/src/common/mainAudio.cpp
@@ -36,7 +36,7 @@ using namespace AudioPlayer;
 
 enum class KeywordActivationState
 {
-    // Initial value, before reading the input configuration file or user selection via keyboard.
+    // Initial value, before reading the input configuration file.
     Undefined, 
 
     // Configuration file did not specify a keyword mode. Keyword activation not possible on this device.
@@ -310,11 +310,11 @@ int main(int argc, char** argv)
             log_t("Now listening...");
             auto future = dialogServiceConnector->ListenOnceAsync();
         }
-        if(s == "2"){
+        if(s == "2" && keywordActivationState != KeywordActivationState::NotSupported){
             keywordActivationState = KeywordActivationState::Paused;
             StartKws();
         }
-        if(s == "3"){
+        if(s == "3" && keywordActivationState != KeywordActivationState::NotSupported){
             StopKws();
         }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix bug #255 - do not turn on KWS after TTS playback is done, if the user has previously selected to stop TTS
* This state machine will also help us easily implement optional barge-in when a configuration settings in the JSON indicates that barge-in needs to be supported (if the device has good echo cancellation). This is logged as feature request #262.
If the process I found out that if we are loading a wrong binary files as the KWS table, no error is generated. Logged as bug #264.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Tested by selecting different sequences of keyboard options 1-3 to make sure everything works as expected. Also tested without keyword table.
