### PR TITLE
Add Barge in as configurable option

### DIFF
--- a/clients/cpp-console/configs/config.json
+++ b/clients/cpp-console/configs/config.json
@@ -6,5 +6,6 @@
   "volume": "25",
   "commands_app_id": "",
   "custom_voice_deployment_ids": "",
-  "log_file_path": ""
+  "log_file_path": "",
+  "barge_in_supported": "true"
 }

--- a/clients/cpp-console/include/AgentConfiguration.h
+++ b/clients/cpp-console/include/AgentConfiguration.h
@@ -49,6 +49,7 @@ public:
     std::string _keywordModelPath;
     std::string _keywordDisplayName;
     std::string _logFilePath;
+    std::string _barge_in_supported;
     unsigned int _volume = 0;
 
     AgentConfiguration();

--- a/clients/cpp-console/src/GGEC/GGECDeviceStatusIndicators.cpp
+++ b/clients/cpp-console/src/GGEC/GGECDeviceStatusIndicators.cpp
@@ -32,6 +32,9 @@ void DeviceStatusIndicators::SetStatus(const DeviceStatus status){
             system("adk-message-send 'led_start_pattern {pattern:10}' >/dev/null");
         break;
     case DeviceStatus::Speaking:
+            //pulse purple
+            system("adk-message-send 'led_start_pattern {pattern:2}' >/dev/null");
+            break;
     default:
         break;
     }

--- a/clients/cpp-console/src/GGEC/GGECLinuxAudioPlayer.cpp
+++ b/clients/cpp-console/src/GGEC/GGECLinuxAudioPlayer.cpp
@@ -220,10 +220,9 @@ int LinuxAudioPlayer::Play(uint8_t* buffer, size_t bufferSize){
 
 int LinuxAudioPlayer::Play(std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::PullAudioOutputStream> pStream){
     int rc = 0;
-    fprintf(stdout, "DEBUG: Play called with stream\n");
+    
     if(m_state == AudioPlayerState::UNINITIALIZED){
         rc = -1;
-        fprintf(stdout, "DEBUG: Play failed. Player uninitialized\n");
     }
     else{
         AudioPlayerEntry entry(pStream);

--- a/clients/cpp-console/src/GGEC/GGECLinuxAudioPlayer.cpp
+++ b/clients/cpp-console/src/GGEC/GGECLinuxAudioPlayer.cpp
@@ -220,9 +220,10 @@ int LinuxAudioPlayer::Play(uint8_t* buffer, size_t bufferSize){
 
 int LinuxAudioPlayer::Play(std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::PullAudioOutputStream> pStream){
     int rc = 0;
-    
+    fprintf(stdout, "DEBUG: Play called with stream\n");
     if(m_state == AudioPlayerState::UNINITIALIZED){
         rc = -1;
+        fprintf(stdout, "DEBUG: Play failed. Player uninitialized\n");
     }
     else{
         AudioPlayerEntry entry(pStream);

--- a/clients/cpp-console/src/common/AgentConfiguration.cpp
+++ b/clients/cpp-console/src/common/AgentConfiguration.cpp
@@ -30,6 +30,7 @@ namespace FieldNames
     constexpr auto CustomEndpoint = "custom_endpoint";
     constexpr auto KeywordDisplay = "keyword_display";
     constexpr auto Volume = "volume";
+    constexpr auto BargeInSupported = "barge_in_supported";
     constexpr auto LogFilePath = "log_file_path";
 }
 
@@ -62,6 +63,7 @@ shared_ptr<AgentConfiguration> AgentConfiguration::LoadFromFile(const string& pa
     config->_keywordDisplayName = j.value(FieldNames::KeywordDisplay, "");
     config->_logFilePath = j.value(FieldNames::LogFilePath, "");
     config->_volume = atoi(j.value(FieldNames::Volume, "").c_str());
+    config->_barge_in_supported = j.value(FieldNames::BargeInSupported, "");
 
 	if (config->_keywordModelPath.length() > 0)
 	{

--- a/clients/cpp-console/src/common/mainAudio.cpp
+++ b/clients/cpp-console/src/common/mainAudio.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
                 newStatus = DeviceStatus::Idle;
         }
         
-        //update the device status
+        // Update the device status
         DeviceStatusIndicators::SetStatus(newStatus);
     };
 
@@ -303,8 +303,8 @@ int main(int argc, char** argv)
             uint32_t total_bytes_read = 0;
             if(volumeOn && player != nullptr){
                 
-                //if we are expecting more input and have audio to play, we will want to wait till all audio is done playing before
-                //before listening again. We can read from the stream here to accomplish this.
+                // If we are expecting more input and have audio to play, we will want to wait till all audio is done playing before
+                // before listening again. We can read from the stream here to accomplish this.
                  if(continue_multiturn){
                     uint32_t playBufferSize = 1024;
                     unsigned int bytesRead = 0;
@@ -317,7 +317,7 @@ int main(int argc, char** argv)
                     
                     DeviceStatusIndicators::SetStatus(DeviceStatus::Speaking);
                     
-                    //we don't want to timeout while tts is playing so start 1 second before it is done
+                    // We don't want to timeout while tts is playing so start 1 second before it is done
                     int secondsOfAudio = total_bytes_read / 32000;
                     std::this_thread::sleep_for(std::chrono::milliseconds((secondsOfAudio-1)*1000));
                 }
@@ -336,7 +336,7 @@ int main(int argc, char** argv)
         if (continue_multiturn)
         {
             log_t("Activity requested a continuation (ExpectingInput) -- listening again");
-            //There may be an issue where the listening times out while the Audio is playing.
+            // There may be an issue where the listening times out while the Audio is playing.
             ContinueListening();
         }
         else


### PR DESCRIPTION
Barge in support can now be triggered by the configuration file.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

Try to barge in with the setting as false/true.