### PR TITLE
Fix background activation with existing MVA keyword configuration retrieval

### DIFF
--- a/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
+++ b/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
@@ -329,6 +329,12 @@ namespace UWPVoiceAssistantSample
         {
             var detector = await GetFirstEligibleDetectorAsync(this.KeywordActivationModelDataFormat);
 
+            if (await detector.GetConfigurationAsync(this.KeywordId, this.KeywordModelId)
+                is ActivationSignalDetectionConfiguration existingConfiguration)
+            {
+                return existingConfiguration;
+            }
+
             // Only one configuration may be active at a time. Before creating a new one, ensure all existing ones
             // are disabled to avoid collisions.
             var configurations = await detector.GetConfigurationsAsync();


### PR DESCRIPTION
## Purpose
* Small fix for a regression in ActivationSignalDetectionConfiguration retrieval that caused background activations to fail when disabling the configuration during launch (before audio retrieval)

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Before: background activation won't work, failing with a cryptic HRESULT during audio initialization with CreateAudioInputNodeAsync
* After: background activation works again