### PR TITLE
Updates to Voice Assistant Test Tool

### DIFF
--- a/clients/csharp-dotnet-core/voice-assistant-test/docs/GETTING-STARTED-GUIDE.md
+++ b/clients/csharp-dotnet-core/voice-assistant-test/docs/GETTING-STARTED-GUIDE.md
@@ -99,7 +99,7 @@ Now, write the test configuration. Copy and paste the following to your text edi
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2300, 8200],
-        "ExpectedResponseLatency": 3000
+        "ExpectedUserPerceivedLatency": 3000
       }
     ]
   }
@@ -113,7 +113,7 @@ The test includes one dialog to verify the bot's greeting. It has the following 
     * TurnId - A non-negative integer that enumerates the turns, starting from 0.
     * ExpectedResponses - This is an array that lists the bot reply activities in the order you expect the client to receive them. Each activity is JSON string that follows the [Bot-Framework Activity schema](https://github.com/Microsoft/botframework-sdk/blob/master/specs/botframework-activity/botframework-activity.md). You only need to list the activity fields that you care about. In the example above, we expect the bot greeting to include two activities of type "message". We list values for "text", "speak", "inputHint" and "attachments". If the actual activities received have different values for these fields, the test will fail. Note that the tool first orders the bot responses based on the [activity timestamp](https://github.com/Microsoft/botframework-sdk/blob/master/specs/botframework-activity/botframework-activity.md#timestamp) field, before comparing to the expected bot responses.
     * ExpectedTTSAudioResponseDurations - An optional array of integers, specifying the expected duration in msec of the resulting Text-to-Speech (TTS) audio stream associated with each bot-reply activity. The length of this array must equal the length of the ExpectedResponses array. If there is no TTS audio associated with any of the bot-reply activities, you can enter a value of -1. The duration does not need to be exact. When the tool compares expected duration to actual duration, there is a tolerance defined by the application configuration setting TTSAudioDurationMargin. Its default value is 200 msec.
-    * ExpectedResponseLatency - Specifies the maximum expected duration to receive all the bot responses, in msec. If the actual duration is larger than the value specified here, the test will fail.
+    * ExpectedUserPerceivedLatency - Specifies the maximum expected duration to receive all the bot responses, in msec. If the actual duration is larger than the value specified here, the test will fail.
 
 ## Step 4: Run your test
 
@@ -145,7 +145,7 @@ Notice that these files and folder were created by the tool:
     * ResponseMatch - True if ActualResponses matched ExpectedResponses
     * UtteranceMatch - True if expected speech recognition matched actual speech recognition result. This is only relevant for turns with WAV file input (to be discussed further down)
     * TTSAudioResponseDurationMatch - True if ActualTTSAudioResponseDuration values are all within the tolerance range of ExpectedTTSAudioResponseDurations.
-    * ResponseLatencyMatch - True if ActualResponseLatency is less or equal ExpectedResponseLatency.
+    * ResponseLatencyMatch - True if ActualUserPerceivedLatency is less or equal ExpectedUserPerceivedLatency.
     * Pass - True if all of the above are true.
 * [TestConfigOutput\WAVFiles\TestConfig-BotResponse-0-0-0.WAV](core-bot-examples/greeting/TestConfigOutput/WAVFiles/TestConfig-BotResponse-0-0-0.WAV) - This is the TTS audio stream associated with the first bot response ("welcome to Bot Framework"). The WAV file name is a concatenation of 
     - test configuration name ("TestConfig" here), followed by 
@@ -160,7 +160,7 @@ Notice that these files and folder were created by the tool:
 Experiment with changing test configurations to see an example of test failure and the corresponding error message. Here are some suggestions:
 * **Missing required field**. Remove the "Region" field in AppConfig.json, or the "DialogID" in TestConfig.json, re-run the test and see the "required property not found" failure message.
 * **Bot-response activity mismatch**. Change the "speak" field of the first expected bot-response in TestConfig.json from "Welcome to Bot Framework!" to just "Welcome". Re-run the test and see the "activity field mismatching values" failure message.
-* **Latency failure**. Update the "ExpectedResponseLatency" field in TestConfig.json to a very small, unrealistic value (e.g. 10 msec), re-run the test and see the "latency mismatch" failure message.
+* **Latency failure**. Update the "ExpectedUserPerceivedLatency" field in TestConfig.json to a very small, unrealistic value (e.g. 10 msec), re-run the test and see the "latency mismatch" failure message.
 
 ## Step 6: Add turns with WAV input
 
@@ -192,7 +192,7 @@ Now that you've verified the expected bot greeting, update your test configurati
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2300, 8200],
-        "ExpectedResponseLatency": 3000
+        "ExpectedUserPerceivedLatency": 3000
       },
       {
         "TurnID": 1,
@@ -207,7 +207,7 @@ Now that you've verified the expected bot greeting, update your test configurati
           }
         ],
         "ExpectedTTSAudioResponseDurations": [9221],
-        "ExpectedResponseLatency": 1000,
+        "ExpectedUserPerceivedLatency": 1000,
       },
       {
         "TurnID": 2,
@@ -228,7 +228,7 @@ Now that you've verified the expected bot greeting, update your test configurati
           }
         ],
         "ExpectedTTSAudioResponseDurations": [5100, 2200],
-        "ExpectedResponseLatency": 1000,
+        "ExpectedUserPerceivedLatency": 1000,
       }
     ]
   }

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
@@ -161,7 +161,7 @@ namespace VoiceAssistantTest
             if (this.appsettings.RealTimeAudio)
             {
                 config.SetProperty("SPEECH-AudioThrottleAsPercentageOfRealTime", "100");
-                config.SetProperty("SPEECH-TransmitLengthBeforThrottleMs", "0");
+                config.SetProperty("SPEECH-TransmitLengthBeforeThrottleMs", "0");
             }
 
             if (this.connector != null)

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/VoiceAssistantTest.csproj
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/VoiceAssistantTest.csproj
@@ -36,15 +36,15 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.7.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.9.1" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="NAudio" Version="1.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">

--- a/custom-commands/hospitality/test/hospitality_skill.json
+++ b/custom-commands/hospitality/test/hospitality_skill.json
@@ -2,99 +2,63 @@
   "Tests": [
     {
       "FileName": "input-files\\Test_FallbackCommand_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_FallbackCommand_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_TurnOnOff_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_TurnOnOff_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_Help_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_Help_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_Greeting_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_Greeting_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_AdjustTemperature_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_AdjustTemperature_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_OpenClose_TextInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     },
     {
       "FileName": "input-files\\Test_OpenClose_VoiceInput.json",
-      "IgnoreActivities": [
-        {
-          "type": "event"
-        }
-      ]
+      "IgnoreActivities": [ { "type": "event" } ],
+      "Skip": false
     }
   ],
   "SpeechSubscriptionKey": "0123456789abcdef0123456789abcdef",

--- a/custom-commands/hospitality/test/hospitality_skill.json
+++ b/custom-commands/hospitality/test/hospitality_skill.json
@@ -97,7 +97,7 @@
       ]
     }
   ],
-  "SubscriptionKey": "0123456789abcdef0123456789abcdef",
-  "Region": "westus2",
+  "SpeechSubscriptionKey": "0123456789abcdef0123456789abcdef",
+  "SpeechRegion": "westus2",
   "CustomCommandsAppId": "abcdef0123456789abcdef0123456789",
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Update all Nugets (including update to Speech SDK 1.12)
* Update doc on UPL measurement
* Fix names of JSON keys related to UPL
* Use the typo-free version of the Speech property SPEECH-TransmitLengthBeforThrottleMs (both should work now, as confirmed when looking at Speech SDK code)
* Update JSON key names to the agreed names to match the previous code changes
* Use a more compact style for the Hospitality test JSON, and add "Skip" fields since we constantly need them when investigating test failures.

Some Hospitality tests are failing due to timeout in the 2nd turn (unrelated to the above changes). Also some UPL numbers are wrong. Will investigate both and fix in a separate  PR.
