### PR TITLE
Fix & simplify UPL calculating in Voice Assistant Test

### DIFF
--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
@@ -45,7 +45,6 @@ namespace VoiceAssistantTest
         private bool keyword;
         private KeywordRecognitionModel kwsTable;
         private int speechDuration = 0;
-        private bool realTimeAudio = false;
 
         /// <summary>
         /// Gets or sets recognized text of the speech input.
@@ -151,7 +150,6 @@ namespace VoiceAssistantTest
 
             if (this.appsettings.RealTimeAudio)
             {
-                this.realTimeAudio = true;
                 config.SetProperty("SPEECH-AudioThrottleAsPercentageOfRealTime", "100");
                 config.SetProperty("SPEECH-TransmitLengthBeforeThrottleMs", "0");
             }
@@ -567,7 +565,7 @@ namespace VoiceAssistantTest
             // TODO: When there is TTS audio, get the elapsed time only after first TTS buffer was received
             int elapsedTime = (int)this.stopWatch.ElapsedMilliseconds;
 
-            if (this.realTimeAudio)
+            if (this.appsettings.RealTimeAudio)
             {
                 // For WAV file input, the timer starts on SessionStart event. If we consume the audio from the input stream at real-time, then by subtracting
                 // the speech duration here, its as if we started the timer at the point that speech stopped. This is what we want to accurately measure UPL.

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
@@ -40,11 +40,12 @@ namespace VoiceAssistantTest
         private int turnID;
         private int indexActivityWithAudio = 0;
         private int ttsStreamDownloadCount = 0;
-        private int elapsedTime = 0;
         private List<Activity> ignoreActivitiesList;
         private Stopwatch stopWatch;
         private bool keyword;
         private KeywordRecognitionModel kwsTable;
+        private int speechDuration = 0;
+        private bool realTimeAudio = false;
 
         /// <summary>
         /// Gets or sets recognized text of the speech input.
@@ -55,16 +56,6 @@ namespace VoiceAssistantTest
         /// Gets or sets recognized keyword.
         /// </summary>
         public string RecognizedKeyword { get; set; }
-
-        /// <summary>
-        /// Gets or sets the actual length of speech in WavFile obtained from RecognizedSpeech event.
-        /// </summary>
-        public int LengthOfSpeechInWavFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets the time in milliseconds between SessionStarted and ActivityReceived events.
-        /// </summary>
-        public int UserPerceivedLatency { get; set; }
 
         private List<BotReply> BotReplyList { get; set; }
 
@@ -160,6 +151,7 @@ namespace VoiceAssistantTest
 
             if (this.appsettings.RealTimeAudio)
             {
+                this.realTimeAudio = true;
                 config.SetProperty("SPEECH-AudioThrottleAsPercentageOfRealTime", "100");
                 config.SetProperty("SPEECH-TransmitLengthBeforeThrottleMs", "0");
             }
@@ -177,7 +169,7 @@ namespace VoiceAssistantTest
             if (this.appsettings.BotGreeting)
             {
                 // Starting the timer to calculate latency for Bot Greeting.
-                this.stopWatch.Start();
+                this.stopWatch.Restart();
             }
 
             this.AttachHandlers();
@@ -295,7 +287,7 @@ namespace VoiceAssistantTest
         public async Task<BotConnector> SendActivity(string activity)
         {
             this.stopWatch.Restart();
-            this.elapsedTime = 0;
+            this.speechDuration = 0;
 
             lock (this.BotReplyList)
             {
@@ -545,9 +537,9 @@ namespace VoiceAssistantTest
             if (e.Result.Reason == ResultReason.RecognizedSpeech)
             {
                 this.RecognizedText = e.Result.Text;
-                this.LengthOfSpeechInWavFile = (int)e.Result.Duration.TotalMilliseconds;
+                this.speechDuration = (int)e.Result.Duration.TotalMilliseconds;
 
-                Trace.TraceInformation($"[{DateTime.Now.ToString("h:mm:ss tt", CultureInfo.CurrentCulture)}] Recognized event received. SessionId = {e.SessionId}");
+                Trace.TraceInformation($"[{DateTime.Now.ToString("h:mm:ss tt", CultureInfo.CurrentCulture)}] Recognized event received. SessionId = {e.SessionId}, Speech duration = {this.speechDuration}, Recognized text = {this.RecognizedText}");
             }
             else if (e.Result.Reason == ResultReason.RecognizedKeyword)
             {
@@ -572,22 +564,27 @@ namespace VoiceAssistantTest
             var json = e.Activity;
             var activity = JsonConvert.DeserializeObject<Activity>(json);
 
-            this.stopWatch.Stop();
+            // TODO: When there is TTS audio, get the elapsed time only after first TTS buffer was received
+            int elapsedTime = (int)this.stopWatch.ElapsedMilliseconds;
 
-            this.elapsedTime += (int)this.stopWatch.ElapsedMilliseconds;
+            if (this.realTimeAudio)
+            {
+                // For WAV file input, the timer starts on SessionStart event. If we consume the audio from the input stream at real-time, then by subtracting
+                // the speech duration here, its as if we started the timer at the point that speech stopped. This is what we want to accurately measure UPL.
+                // For any other input (text or Activity), the speechDuration value is not relevant and should be zero at this point.
+                elapsedTime -= this.speechDuration;
+            }
 
-            this.UserPerceivedLatency = this.elapsedTime - this.LengthOfSpeechInWavFile;
+            Trace.TraceInformation($"[{DateTime.Now.ToString("h:mm:ss tt", CultureInfo.CurrentCulture)}] Activity received, elapsedTime = {elapsedTime}, speechDuration = {this.speechDuration}");
 
             int activityIndex = 0;
             int ttsDuration = 0;
 
             lock (this.BotReplyList)
             {
-                this.BotReplyList.Add(new BotReply(activity, this.elapsedTime, false));
+                this.BotReplyList.Add(new BotReply(activity, elapsedTime, false));
                 activityIndex = this.BotReplyList.Count - 1;
             }
-
-            this.elapsedTime = 0;
 
             if (e.HasAudio)
             {
@@ -600,8 +597,6 @@ namespace VoiceAssistantTest
                     this.BotReplyList[activityIndex].TTSAudioDuration = ttsDuration;
                 }
             }
-
-            this.stopWatch.Restart();
         }
 
         private void SpeechBotConnector_Canceled(object sender, SpeechRecognitionCanceledEventArgs e)
@@ -618,7 +613,7 @@ namespace VoiceAssistantTest
 
         private void SpeechBotConnector_SessionStarted(object sender, SessionEventArgs e)
         {
-            this.stopWatch.Start();
+            this.stopWatch.Restart();
             Trace.TraceInformation($"[{DateTime.Now.ToString("h:mm:ss tt", CultureInfo.CurrentCulture)}] Session Started event received. SessionId = {e.SessionId}");
         }
 

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/DialogResult.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/DialogResult.cs
@@ -217,8 +217,8 @@ namespace VoiceAssistantTest
         /// </summary>
         /// <param name="turn"> Input Turns.</param>
         /// <param name="bootstrapMode">Boolean which defines if turn is in bootstrapping mode or not.</param>
-        /// <param name="recognizedText">Recognized text from Speech Recongition.</param>
-        /// <param name="recognizedKeyword">Recogized Keyword from Keyword Recognition.</param>
+        /// <param name="recognizedText">Recognized text from Speech Recognition.</param>
+        /// <param name="recognizedKeyword">Recognized Keyword from Keyword Recognition.</param>
         /// <returns>TurnsOutput.</returns>
         public TurnResult BuildOutput(Turn turn, bool bootstrapMode, string recognizedText, string recognizedKeyword)
         {

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
@@ -308,8 +308,6 @@ namespace VoiceAssistantTest
                             testPass = false;
                         }
 
-                        turnResult.ActualUserPerceivedLatency = botConnector.UserPerceivedLatency;
-
                         // Add the turn result to the list of turn results.
                         turnResults.Add(turnResult);
 

--- a/custom-commands/hospitality/test/hospitality_skill.json
+++ b/custom-commands/hospitality/test/hospitality_skill.json
@@ -64,4 +64,6 @@
   "SpeechSubscriptionKey": "0123456789abcdef0123456789abcdef",
   "SpeechRegion": "westus2",
   "CustomCommandsAppId": "abcdef0123456789abcdef0123456789",
+  "RealTimeAudio": false,
+  "Timeout": 5000
 }

--- a/custom-commands/hospitality/test/input-files/Test_AdjustTemperature_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_AdjustTemperature_TextInput.json
@@ -15,7 +15,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [4300],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -29,7 +29,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -49,7 +49,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": ["3300 || 2000"],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -63,7 +63,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -77,7 +77,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -97,7 +97,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3950],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -117,7 +117,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3950],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -137,7 +137,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -151,7 +151,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [4350],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -165,7 +165,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -185,7 +185,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -199,7 +199,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -219,7 +219,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3600],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -239,7 +239,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -253,7 +253,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -273,7 +273,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -287,7 +287,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -307,7 +307,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -321,7 +321,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3900],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -341,7 +341,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -355,7 +355,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3850],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_AdjustTemperature_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_AdjustTemperature_VoiceInput.json
@@ -16,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [4300],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -31,7 +31,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -52,7 +52,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": ["3300 || 2000"],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -67,7 +67,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -82,7 +82,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -103,7 +103,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3950],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -124,7 +124,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3950],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -145,7 +145,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -160,7 +160,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [4350],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -175,7 +175,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -196,7 +196,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -211,7 +211,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -232,7 +232,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3600],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -253,7 +253,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -268,7 +268,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -289,7 +289,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -304,7 +304,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -325,7 +325,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -340,7 +340,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3900],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -361,7 +361,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2750],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -376,7 +376,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3850],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_FallbackCommand_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_FallbackCommand_TextInput.json
@@ -15,7 +15,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": ["3500 || 2500"],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_FallbackCommand_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_FallbackCommand_VoiceInput.json
@@ -16,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": ["3500 || 2500"],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_Greeting_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_Greeting_TextInput.json
@@ -15,7 +15,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -29,7 +29,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -43,7 +43,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_Greeting_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_Greeting_VoiceInput.json
@@ -16,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -31,7 +31,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -46,7 +46,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [1000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_Help_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_Help_TextInput.json
@@ -15,7 +15,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -29,7 +29,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -43,7 +43,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_Help_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_Help_VoiceInput.json
@@ -16,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -31,7 +31,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -46,7 +46,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [11650],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_OpenClose_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_OpenClose_TextInput.json
@@ -15,7 +15,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -35,7 +35,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -55,7 +55,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -75,7 +75,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_OpenClose_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_OpenClose_VoiceInput.json
@@ -16,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -37,7 +37,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -58,7 +58,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
@@ -79,7 +79,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_TurnOnOff_TextInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_TurnOnOff_TextInput.json
@@ -1,6 +1,7 @@
 [
   {
     "DialogID": "0",
+    "Skip": false,
     "Description": "Testing 'turn it {OnOff}'",
     "Turns": [
       {
@@ -15,7 +16,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -29,12 +30,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "1",
+    "Skip": false,
     "Description": "Testing 'turn the {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -49,12 +51,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "2",
+    "Skip": false,
     "Description": "Testing 'turn the {SubjectContext} {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -69,12 +72,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "3",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff} the {SubjectDevice}'",
     "Turns": [
       {
@@ -89,12 +93,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2500],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "4",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff} the {SubjectContext} {SubjectDevice}'",
     "Turns": [
       {
@@ -109,12 +114,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "5",
+    "Skip": false,
     "Description": "Testing '{SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -129,12 +135,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "6",
+    "Skip": false,
     "Description": "Testing 'I want the {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -149,12 +156,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "7",
+    "Skip": false,
     "Description": "Testing 'control a device'",
     "Turns": [
       {
@@ -169,7 +177,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -183,7 +191,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -197,12 +205,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "8",
+    "Skip": false,
     "Description": "Testing 'I want to control a device'",
     "Turns": [
       {
@@ -217,7 +226,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -231,7 +240,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 2,
@@ -245,12 +254,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2600],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   },
   {
     "DialogID": "9",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff}'",
     "Turns": [
       {
@@ -265,7 +275,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       },
       {
         "TurnID": 1,
@@ -279,7 +289,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 1500
       }
     ]
   }

--- a/custom-commands/hospitality/test/input-files/Test_TurnOnOff_VoiceInput.json
+++ b/custom-commands/hospitality/test/input-files/Test_TurnOnOff_VoiceInput.json
@@ -1,6 +1,7 @@
 [
   {
     "DialogID": "0",
+    "Skip": false,
     "Description": "Testing 'turn it {OnOff}'",
     "Turns": [
       {
@@ -16,7 +17,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 1,
@@ -31,12 +32,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "1",
+    "Skip": false,
     "Description": "Testing 'turn the {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -52,12 +54,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2800],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "2",
+    "Skip": false,
     "Description": "Testing 'turn the {SubjectContext} {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -73,12 +76,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "3",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff} the {SubjectDevice}'",
     "Turns": [
       {
@@ -94,12 +98,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2500],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "4",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff} the {SubjectContext} {SubjectDevice}'",
     "Turns": [
       {
@@ -115,12 +120,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "5",
+    "Skip": false,
     "Description": "Testing '{SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -136,12 +142,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "6",
+    "Skip": false,
     "Description": "Testing 'I want the {SubjectDevice} {OnOff}'",
     "Turns": [
       {
@@ -157,12 +164,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "7",
+    "Skip": false,
     "Description": "Testing 'control a device'",
     "Turns": [
       {
@@ -178,7 +186,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 1,
@@ -193,7 +201,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 2,
@@ -208,12 +216,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "8",
+    "Skip": false,
     "Description": "Testing 'I want to control a device'",
     "Turns": [
       {
@@ -229,7 +238,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2700],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 1,
@@ -244,7 +253,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 2,
@@ -259,12 +268,13 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [2600],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   },
   {
     "DialogID": "9",
+    "Skip": false,
     "Description": "Testing 'turn {OnOff}'",
     "Turns": [
       {
@@ -280,7 +290,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       },
       {
         "TurnID": 1,
@@ -295,7 +305,7 @@
           }
         ],
         "ExpectedTTSAudioResponseDurations": [3000],
-        "ExpectedResponseLatency": 1500
+        "ExpectedUserPerceivedLatency": 10000
       }
     ]
   }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* There was a duplication of "Latency" values stored in BotReply objects and a separate UPL values which the BotConnector returns. Unify them and only calculate and report UPL.
* Update test configuration to use the expected UPL instead of just expected latency
* Simplify how the stopwatch is managed. No need to start/stop so many times. Restart once on SettionStrart, and then read elapsed time when an activity is received. 

Hospitality WAV tests are failing, unrelated to the above changes, because for some reason it takes 4-5 seconds to get a reply in the test, even though when I do the same thing manually using Windows Voice Assistant Client everything runs fast. I'll file a bug on it.

Also, we need to wait and get elapsed time when the first TTS audio buffer is received, not when the activity is received. I'll open a work item on that.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```