### PR TITLE
Fix existing keyword configuration

### DIFF
--- a/clients/csharp-uwp/README.md
+++ b/clients/csharp-uwp/README.md
@@ -63,8 +63,8 @@ To debug the app and then run it, press F5 or use **Debug > Start Debugging**. T
 
 ### Optional:
 
-- You can train a [Custom Speech Recognition Model](https://speech.microsoft.com/customspeech) to improve speech recognition quality. To use your custom model, [update the config file](updating-the-config.json-file) with the Speech Recognition endpoint id.
-- You can create a [Custom Voice](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice-create-voice) for your application's output audio. When you have created your Custom Voice,  To use your custom model, [update the config file](updating-the-config.json-file) with the Custom Voice ID.
+- You can train a [Custom Speech Recognition Model](https://speech.microsoft.com/customspeech) to improve speech recognition quality. To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L4) with the Speech Recognition endpoint id.
+- You can create a [Custom Voice](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice-create-voice) for your application's output audio. When you have created your Custom Voice,  To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L5) with the Custom Voice ID.
 - Toggle the controls for debugging purposes
     -Microphone file capture: creates log files of audio captured when the keyword was detected by MVA
     -SDK logging: enables logging from the DLS SDK to an output file.
@@ -85,6 +85,31 @@ If your first stage keyword model is a hardware keyword, the bin file can be omi
 <br>
 By default, EnableKwsLogging and EnableHardwareDetector are false and SetModelData is true.
 
+#### Using a Hardware Keyword Spotter
+
+To use a Hardware Keyword Spotter create a folder called aarlog in C:/ and within a file called aarconfig.txt.
+This file must have the following format
+
+```
+KeywordDisplayName,{KeywordId},KeywordModelId,Microsoft.SDKSample.MVADLSSampleCS_8wekyb3d8bbwe!App,background
+```
+
+This arrconfig.txt file should look like this for a hardware keyword spotter for Contoso.
+<br>
+Note: This is an example, the Contoso is not a hardware keyword
+
+```
+Contoso,{C0F1842F-D389-44D1-8420-A32A63B35568},1033,Microsoft.SDKSample.MVADLSSampleCS_8wekyb3d8bbwe!App,background
+```
+
+After creating this file (C:/aarlog/aarconfig.txt), open the registry and navigate to Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Speech_OneCore\Settings\VoiceActivation and create a new DWORD (32-bit) Value with the name being "UseAarConfigFile" and set its value to Hexadecimal 1.
+
+Restart AarSvc_####
+
+Open the config file and add two additional Key-Value pairs. **EnableHardwareDetector: true** and **SetModelData: false**
+
+The path to the bin file should be omitted in the KeywordActivationModel when using a hardware keyword spotter.
+
 #### Enabling KWS+KWV+SR only mode
 
 Each utterance returns a bot response, this response can be ignored by the client by adding a property to the DialogServiceConnector object. When using this property you will have to set the SpeechRegion to an empty string and the following in the SetProperty key:
@@ -101,7 +126,7 @@ Each utterance returns a bot response, this response can be ignored by the clien
 - Visit [Create Custom Wake Word](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-devices-sdk-create-kws) and save the .table file.
 - Obtain a whitelisted AppID, GUID, and Keyword Display Name from Microsoft, as well as a bin file containing a model for your keyword. 
 - Add the .table and .bin files to the UWPVoiceAssistantSample/SDKKeywords folder before building the application.
-- After running the application, [update the config file](updating-the-config.json-file) by replacing all fields in the KeywordActivationModel and KeywordModel. 
+- After running the application, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L9) by replacing all fields in the KeywordActivationModel and KeywordRecognitionModel. 
 
 After First Run, you may want to verify that the Keyword was correctly registered to the device. To do so:
 - Open Registry Editor

--- a/clients/csharp-uwp/README.md
+++ b/clients/csharp-uwp/README.md
@@ -85,31 +85,6 @@ If your first stage keyword model is a hardware keyword, the bin file can be omi
 <br>
 By default, EnableKwsLogging and EnableHardwareDetector are false and SetModelData is true.
 
-#### Using a Hardware Keyword Spotter
-
-To use a Hardware Keyword Spotter create a folder called aarlog in C:\ and within a file called aarconfig.txt.
-This file must have the following format
-
-```
-KeywordDisplayName,{KeywordId},KeywordModelId,Microsoft.SDKSample.MVADLSSampleCS_8wekyb3d8bbwe!App,background
-```
-
-This arrconfig.txt file should look like this for a hardware keyword spotter for Contoso.
-<br>
-Note: This is an example, the Contoso is not a hardware keyword
-
-```
-Contoso,{C0F1842F-D389-44D1-8420-A32A63B35568},1033,Microsoft.SDKSample.MVADLSSampleCS_8wekyb3d8bbwe!App,background
-```
-
-After creating this file (C:\aarlog\aarconfig.txt), open the registry and navigate to Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Speech_OneCore\Settings\VoiceActivation and create a new DWORD (32-bit) Value with the name being "UseAarConfigFile" and set its value to Hexadecimal 1.
-
-Restart AarSvc_####
-
-Open the config file and add two additional Key-Value pairs. **EnableHardwareDetector: true** and **SetModelData: false**
-
-The path to the bin file should be omitted in the KeywordActivationModel when using a hardware keyword spotter.
-
 #### Enabling KWS+KWV+SR only mode
 
 Each utterance returns a bot response, this response can be ignored by the client by adding a property to the DialogServiceConnector object. When using this property you will have to set the SpeechRegion to an empty string and the following in the SetProperty key:

--- a/clients/csharp-uwp/README.md
+++ b/clients/csharp-uwp/README.md
@@ -63,8 +63,8 @@ To debug the app and then run it, press F5 or use **Debug > Start Debugging**. T
 
 ### Optional:
 
-- You can train a [Custom Speech Recognition Model](https://speech.microsoft.com/customspeech) to improve speech recognition quality. To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L4) with the Speech Recognition endpoint id.
-- You can create a [Custom Voice](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice-create-voice) for your application's output audio. When you have created your Custom Voice,  To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L5) with the Custom Voice ID.
+- You can train a [Custom Speech Recognition Model](https://speech.microsoft.com/customspeech) to improve speech recognition quality. To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/master/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json) with the Speech Recognition endpoint id.
+- You can create a [Custom Voice](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice-create-voice) for your application's output audio. When you have created your Custom Voice,  To use your custom model, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/master/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json) with the Custom Voice ID.
 - Toggle the controls for debugging purposes
     -Microphone file capture: creates log files of audio captured when the keyword was detected by MVA
     -SDK logging: enables logging from the DLS SDK to an output file.
@@ -87,7 +87,7 @@ By default, EnableKwsLogging and EnableHardwareDetector are false and SetModelDa
 
 #### Using a Hardware Keyword Spotter
 
-To use a Hardware Keyword Spotter create a folder called aarlog in C:/ and within a file called aarconfig.txt.
+To use a Hardware Keyword Spotter create a folder called aarlog in C:\ and within a file called aarconfig.txt.
 This file must have the following format
 
 ```
@@ -102,7 +102,7 @@ Note: This is an example, the Contoso is not a hardware keyword
 Contoso,{C0F1842F-D389-44D1-8420-A32A63B35568},1033,Microsoft.SDKSample.MVADLSSampleCS_8wekyb3d8bbwe!App,background
 ```
 
-After creating this file (C:/aarlog/aarconfig.txt), open the registry and navigate to Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Speech_OneCore\Settings\VoiceActivation and create a new DWORD (32-bit) Value with the name being "UseAarConfigFile" and set its value to Hexadecimal 1.
+After creating this file (C:\aarlog\aarconfig.txt), open the registry and navigate to Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Speech_OneCore\Settings\VoiceActivation and create a new DWORD (32-bit) Value with the name being "UseAarConfigFile" and set its value to Hexadecimal 1.
 
 Restart AarSvc_####
 
@@ -126,7 +126,7 @@ Each utterance returns a bot response, this response can be ignored by the clien
 - Visit [Create Custom Wake Word](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-devices-sdk-create-kws) and save the .table file.
 - Obtain a whitelisted AppID, GUID, and Keyword Display Name from Microsoft, as well as a bin file containing a model for your keyword. 
 - Add the .table and .bin files to the UWPVoiceAssistantSample/SDKKeywords folder before building the application.
-- After running the application, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/fa8b68b4e65bbff75e5168888526109a606df29f/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json#L9) by replacing all fields in the KeywordActivationModel and KeywordRecognitionModel. 
+- After running the application, [update the config file](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/blob/master/clients/csharp-uwp/UWPVoiceAssistantSample/Assets/defaultConfig.json) by replacing all fields in the KeywordActivationModel and KeywordRecognitionModel. 
 
 After First Run, you may want to verify that the Keyword was correctly registered to the device. To do so:
 - Open Registry Editor

--- a/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
+++ b/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
@@ -154,6 +154,15 @@ namespace UWPVoiceAssistantSample
                     return this.keywordConfiguration;
                 }
 
+                var detector = await GetDetectorAsync(this.KeywordActivationModelDataFormat);
+
+                if (await detector.GetConfigurationAsync(this.KeywordId, this.KeywordModelId)
+                    is ActivationSignalDetectionConfiguration existingConfiguration)
+                {
+                    await this.SetModelDataIfNeededAsync(existingConfiguration);
+                    return existingConfiguration;
+                }
+
                 return await this.CreateKeywordConfigurationAsyncInternal();
             }
         }
@@ -334,6 +343,7 @@ namespace UWPVoiceAssistantSample
             var configurations = await detector.GetConfigurationsAsync();
             foreach (var configuration in configurations)
             {
+                await this.SetModelDataIfNeededAsync(configuration);
                 await configuration.SetEnabledAsync(false);
             }
 

--- a/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
+++ b/clients/csharp-uwp/UWPVoiceAssistantSample/KeywordRegistration.cs
@@ -159,8 +159,10 @@ namespace UWPVoiceAssistantSample
                 if (await detector.GetConfigurationAsync(this.KeywordId, this.KeywordModelId)
                     is ActivationSignalDetectionConfiguration existingConfiguration)
                 {
+                    LocalSettingsHelper.SetModelData = true;
                     await this.SetModelDataIfNeededAsync(existingConfiguration);
-                    return existingConfiguration;
+                    await existingConfiguration.SetEnabledAsync(true);
+                    return await this.CreateKeywordConfigurationAsyncInternal();
                 }
 
                 return await this.CreateKeywordConfigurationAsyncInternal();


### PR DESCRIPTION
## Purpose
* An existing keyword configuration was not enabled because its model data was not set. This issue was raised when another MVA app was registered and uninstalled. The keyword from the initial MVA App remained disabled after enabling Voice Activation. 
* In this PR, the existing configuration is retrieved, its model data is set, and it is enabled.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
* Install the UWP Voice Assistant Sample (MVA App 1) Voice Activate
* Install another MVA App (MVA App 2), disable Voice Activation for MVA App 1
* Voice Activate MVA App 2.
* Uninstall MVA App 2 and enabled Voice Activation for MVA App 1
* Before this Fix, the registered keyword for MVA App 1 remained disabled.
* After this fix, keyword for MVA App 1 is enabled and allowed to Voice Activate. 
