### PR TITLE
Fixed Custom Keywords in deployment script

### DIFF
--- a/custom-commands/scripts/deployAll.ps1
+++ b/custom-commands/scripts/deployAll.ps1
@@ -44,7 +44,7 @@ else {
 
 # get the current default subscription ID
 $userName = (az ad signed-in-user show | ConvertFrom-Json).userPrincipalName
-Write-Host -ForegroundColor Yellow "`nThe login Azure account ($userName) has following subscription(s):"
+Write-Host -ForegroundColor Yellow "`nThe logged in Azure account ($userName) has following subscription(s):"
 az account list --all --output json | ConvertFrom-Json | Select-Object -Property isDefault, state, name, id | Out-Default
 $defaultSubscription = az account list --all --output json | ConvertFrom-Json | Where-Object { $_.isDefault -eq "true" }
 $subscriptionName = $defaultSubscription.name

--- a/custom-commands/scripts/deployCustomCommands.ps1
+++ b/custom-commands/scripts/deployCustomCommands.ps1
@@ -64,33 +64,15 @@ write-host "Created project Id $appId"
 # update the dialog model of the app
 #
 
-# get the current model so that we can modify it
-write-host "getting the initial $speechAppName $appName commands model"
-try {
-    $model = invoke-restmethod -Method GET -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/apps/$appId/stages/default/cultures/en-us" -Header $headers
-}
-catch {
-    # dig into the exception to get the Response details.
-    # note that value__ is not a typo.
-    Write-Host $_.Exception
-    Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 
-    Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
-    exit
-}
-
 # change the model based on the local json file
 write-host "patching the $speechAppName $appName commands model"
 $newModel = Get-Content $skillJson | Out-String | ConvertFrom-Json
-$model.httpEndpoints = $newModel.httpEndpoints
-$model.httpEndpoints[0].url = $websiteAddress
-$model.lgTemplates = $newModel.lgTemplates
-$model.globalParameters = $newModel.globalParameters
-$model.commands = $newModel.commands
+$newModel.httpEndpoints[0].url = $websiteAddress
 
 # send the updated model up to the application
 write-host "updating $speechAppName with the new $appName commands model"
 try {
-    $response = invoke-restmethod -Method PUT -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/apps/$appId/stages/default/cultures/en-us" -Body ($model | ConvertTo-Json  -depth 100) -Header $headers
+    $response = invoke-restmethod -Method PUT -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/apps/$appId/stages/default/cultures/en-us" -Body ($newModel | ConvertTo-Json  -depth 100) -Header $headers
 }
 catch {
     # dig into the exception to get the Response details.


### PR DESCRIPTION
## Purpose
Updated deployment script to only use new model. Fixed typo in main script
Closes #428 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

deploy a demo and check the custom keywords