### PR TITLE
Add LinuxARM script

### DIFF
--- a/clients/cpp-console/scripts/linux/buildArmLinux.sh
+++ b/clients/cpp-console/scripts/linux/buildArmLinux.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+clear
+cd ../..
+if [ ! -d out ]; then
+    mkdir out # only create directory if does not exist
+fi
+if [ ! -d SDK ]; then
+    mkdir SDK # only create directory if does not exist
+fi
+
+# Determine if the Linux is ARM32 or ARM64
+ARCH=$(uname -m)
+if [[ $ARCH =~ "v7" ]] # ARM32 OS in use
+then
+echo "Running on ARM32 Linux"
+    #echo "Running on ARM32 Linux, creating lib/lib link to lib/arm32"
+LIBLINK="arm32"
+    #ln -s arm32 lib/lib
+else
+    #echo "Running on ARM64 Linux, creating lib/lib link to lib/arm64"
+    #ln -s arm64 lib/lib
+echo "Running on ARM64 Linux"
+LIBLINK="arm64"
+fi
+
+if [ ! -f ./lib/lib/libMicrosoft.CognitiveServices.Speech.core.so ]; then
+echo "Cleaning up libs and include directories that we will overwrite"
+rm -R ./lib/*
+rm -R ./include/c_api
+rm -R ./include/cxx_api
+
+echo "Downloading Speech SDK binaries"
+wget -c https://aka.ms/csspeech/linuxbinary -O - | tar -xz -C ./SDK
+
+echo "Copying SDK binaries to lib folder and headers to include"
+cp -Rf ./SDK/SpeechSDK*/lib .
+cp -Rf ./SDK/SpeechSDK*/include .
+
+echo "Creating lib/lib link to lib/$LIBLINK"
+ln -s $LIBLINK lib/lib
+
+else
+echo "Speech SDK lib found. Skipping download."
+fi
+
+echo "Building Linux Arm sample ..."
+if g++ -Wno-psabi \
+src/common/Main.cpp \
+src/linux/LinuxAudioPlayer.cpp \
+src/common/AudioPlayerEntry.cpp \
+src/common/AgentConfiguration.cpp \
+src/common/DeviceStatusIndicators.cpp \
+src/common/DialogManager.cpp \
+-o ./out/sample.exe \
+-std=c++14 \
+-D LINUX \
+-D MAS \
+-L./lib/lib \
+-I./include/cxx_api \
+-I./include/c_api \
+-I./include \
+-pthread \
+-lstdc++fs \
+-lasound \
+-lMicrosoft.CognitiveServices.Speech.core; 
+then
+error=0;
+else
+error=1;
+fi
+
+cp ./scripts/run.sh ./out
+chmod +x ./out/run.sh
+
+echo Cleaning up downloaded files
+rm -R ./SDK
+
+echo Done. To start the demo execute:
+echo cd ../../out
+echo export LD_LIBRARY_PATH="../lib/lib"
+echo ./sample.exe [path_to_configFile]
+
+exit $error


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This introduces a generic Build script for Linux ARM and closes #451 
* However it needs some discussion on the documentation and impact on other scripts, eg the service and MAS. How do we manage the docs for device specific information, and generic Linux information. For instance on Jetson board I basically followed the "RaspberryPi" doc, do we rename it?


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Test on Raspberry Pi with Ubuntu ARM32
Test on NVidia Jetson with Ubuntu ARM64

## What to Check
Verify that the following are valid
* Ensure it builds the correct version when using ./buildArmLinux.sh
* Test it twice, to ensure it builds with and without downloading the Speech SDK

## Other Information
<!-- Add any other helpful information that may be needed here. -->