### PR TITLE
Lock on the WavOutEvent object

### DIFF
--- a/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -715,7 +715,11 @@ namespace VoiceAssistantClient
             if (entry != null)
             {
                 System.Diagnostics.Debug.WriteLine($"START playing {entry.Id}");
-                this.player.Init(entry.Reader);
+                lock (this.player)
+                {
+                    this.player.Init(entry.Reader);
+                }
+
                 this.player.Play();
                 return true;
             }


### PR DESCRIPTION
## Purpose
* Add a lock to the WavOutEvent Object during initialization

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Thread lock on the audio player initialization
