### PR TITLE
Fix regression in Windows Voice Assistant Client

### DIFF
--- a/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
+++ b/clients/csharp-wpf/VoiceAssistantClient/SettingsDialog.xaml
@@ -170,6 +170,6 @@
             <Button Name="DeleteProfile" Content="Delete Profile" Width="auto" Padding="8,0,8,0" Margin="5,0" Click="DeleteProfile_Click"/>
             <Button Name="CancelButton" Content="Discard Profile Changes" IsCancel="True" Width="auto" Padding="8,0,8,0" Margin="5,0" Click="CancelButton_Click"/>
         </StackPanel>
-        <TextBlock x:Name="GitHubPageTextBlock" Grid.Row="2"><Hyperlink NavigateUri="https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/tree/master/clients/csharp-wpf" RequestNavigate="GitHubPageHyperlink_RequestNavigate">GitHub Page</Hyperlink></TextBlock>
+        <TextBlock x:Name="GitHubPageTextBlock" Grid.Row="2" HorizontalAlignment="Left" Width="70"><Hyperlink NavigateUri="https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant/tree/master/clients/csharp-wpf" RequestNavigate="GitHubPageHyperlink_RequestNavigate">GitHub Page</Hyperlink></TextBlock>
     </Grid>
 </Window>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The settings buttons are not working (e.g. "save and apply profile")
* This is a regression as a result of the "GitHub" link that was added to the settings page

The fix is to limit the size of the "GitHub" text box. By default it covers the whole row and masks the buttons, as Chris pointed out (Thanks Chris!)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
