### PR TITLE
Remove dependency on NuGet Extended.Wpf.Toolkit

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2295,24 +2295,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -------------------------------------------------------------------
 
-AdaptiveCards.Rendering.Wpf.Xceed 1.2.4 - MIT
-(c) 2008 VeriSign, Inc.
-(c) Microsoft Corporation.
-
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
--------------------------------------------------------------------
-
--------------------------------------------------------------------
-
 Jot 1.4.1 - MIT
 Copyright 2017
 (c) 2008 VeriSign, Inc.
@@ -2933,82 +2915,6 @@ This license governs use of the accompanying software. If you use the software, 
 
 -------------------------------------------------------------------
 
-Extended.Wpf.Toolkit 3.7.0 - OTHER
-(c) 2006 thawte, Inc.
-(c) 2008 VeriSign, Inc.
-(c) Copyright Xceed Software, Inc.
-Copyright (c) Xceed Software Inc. 2007-2018
-Copyright (c) Xceed Software Inc. 2010-2019 Extended WPF Toolkit
-Copyright (c) Xceed Software Inc. 2007-2018 nXceed.Wpf.Toolkit.Themes.Office2007,PublicKey
-
-XCEED SOFTWARE, INC.
-
-COMMUNITY LICENSE AGREEMENT (for non-commercial use)
-
-This "Agreement" is a legal agreement between you, a software developer ("Licensee") and Xceed Software, Inc. ("Xceed"). 
-You, the Licensee, wish to use Xceed's product "Xceed Extended WPF Toolkit" (the "Software"), an Xceed product, for use 
-in a non-commercial application or system or program. "Non-Commercial use" means not primarily intended for commercial 
-advantages or for monetary compensation or any other type of compensation. Xceed agrees to license its products to 
-developers like you as along as all terms & conditions set forth herein are respected. Xceed Software is provided under 
-a license; it is not "sold" in any manner. By installing, copying or otherwise using the Software, you confirm your 
-agreement to the terms and conditions expressed in this Agreement. If you do not agree, you are not authorized to use our 
-Software. If you are not a software developer, you are not authorized to use our Software.
-
-
-GENERAL
-
-This license is perpetual (or until revoked by Xceed), provided that:
--All License Agreement terms & conditions are strictly followed by the Licensee;
--Xceed Software is used for non-commercial purposes only (no re-selling, licensing or sub-licensing or any other rights of 
-use);
--Xceed's name and logo must appear clearly in the resulting work with an Xceed Copyright notice; the name and notice must be 
-visible, not be hidden.
-
-Pursuant to these conditions, Xceed grants to Licensee a non-exclusive right to install and use the Software for designing, 
-building, testing and/or deploying an application or system or program for non-commercial purposes only, without the need to 
-acquire a subscription. Would Licensee need to use the Software in any commercial way or purpose, Licensee must acquire a 
-Commercial License (with a paid subscription).
-
-Licensee is not authorized to:
--sell or license/sub-license/lease the resulting work to anyone nor charge any amounts of money or exchange services for the 
-said resulting work;
--"deploy" the Software for/in a commercial environment;
--create a competitive software product based on Xceed Software;
-
-
-SUPPORT
-
-Support is not included in Community Licenses. The Software is provided on an "as is" basis only. Licensee can send requests 
-to Xceed's technical support team only if a commercial license has been obtained. Bugs may be corrected at Xceed's discretion.
-
-
-WARRANTY
-
-Xceed clearly states that this Community License includes no warranty of any type. Xceed products are provided on an "as is" 
-basis. In no case shall Xceed be responsible or liable for any direct or indirect, or consequential damages whatsoever (including, 
-without limitation, any damages for loss of revenues, of business profits, business interruption, or loss of business information, 
-or any other type of loss or damages) arising out of the use of the Software even if Xceed may have been advised of such potential 
-damages or loss.
-
-
-OTHER
-
-Xceed does not allow Community Licensees to publish results from benchmarks or performance comparison tests (with other products) 
-without advance permission by Xceed. Licensee is not authorized to use Xceed's name, tradenames and trademarks without Xceed's written 
-permission (other than the Copyright notice stated above in the "General" section).
-
-
-GOVERNING LAW
-
-This Agreement shall be governed by the laws of the Province of Quebec (Canada). Any claim, dispute or problem arising out of this 
-Agreement shall be deemed non-receivable or may be settled or disposed of at Xceed's discretion. Xceed reserves the right to settle 
-any action before an arbitration board in Quebec as per generally accepted, international rules of arbitration prevailing in Quebec.
-
-Xceed reserves the right to modify this Agreement at all times without notice.
-
-(C) Copyright: Xceed Software, Inc. - 2019. All rights reserved.
-
--------------------------------------------------------------------
     __ _____ _____ _____
  __|  |   __|     |   | |  JSON for Modern C++
 |  |  |__   |  |  | | | |  version 3.7.3

--- a/clients/csharp-wpf/VoiceAssistantClient/App.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/App.config
@@ -10,10 +10,6 @@
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Xceed.Wpf.Toolkit" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.MarkedNet" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.13.0" newVersion="1.0.13.0" />
       </dependentAssembly>

--- a/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
+++ b/clients/csharp-wpf/VoiceAssistantClient/MainWindow.xaml.cs
@@ -56,7 +56,19 @@ namespace VoiceAssistantClient
             Services.Tracker.Configure(this.settings).Apply();
 
             this.renderer = new AdaptiveCardRenderer();
-            this.renderer.UseXceedElementRenderers();
+
+            /*
+              Xceed Enhanced Input Package
+              This optional package enhances the Adaptive Card input controls beyond what WPF provides out of the box.
+              To enable it:
+              1. Add the NuGet package Extended.Wpf.Toolkit by Xceed to the project
+              2. Add the NuGet package AdaptiveCards.Rendering.Wpf.Xceed by Microsoft to the project
+              3. Uncomment the one line below
+              This option is not included here because of its license terms.
+              For more info: https://docs.microsoft.com/en-us/adaptive-cards/sdk/rendering-cards/net-wpf/getting-started
+            */
+            // this.renderer.UseXceedElementRenderers();
+
             var configFile = Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, "AdaptiveCardsHostConfig.json");
             if (File.Exists(configFile))
             {

--- a/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
+++ b/clients/csharp-wpf/VoiceAssistantClient/VoiceAssistantClient.csproj
@@ -104,9 +104,6 @@
     <Reference Include="AdaptiveCards.Rendering.Wpf, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\AdaptiveCards.Rendering.Wpf.1.2.4\lib\net452\AdaptiveCards.Rendering.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="AdaptiveCards.Rendering.Wpf.Xceed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\AdaptiveCards.Rendering.Wpf.Xceed.1.2.4\lib\net452\AdaptiveCards.Rendering.Wpf.Xceed.dll</HintPath>
-    </Reference>
     <Reference Include="Jot, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Jot.1.4.1\lib\net45\Jot.dll</HintPath>
     </Reference>
@@ -152,21 +149,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.Toolkit, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/clients/csharp-wpf/VoiceAssistantClient/packages.config
+++ b/clients/csharp-wpf/VoiceAssistantClient/packages.config
@@ -2,8 +2,6 @@
 <packages>
   <package id="AdaptiveCards" version="1.2.4" targetFramework="net461" />
   <package id="AdaptiveCards.Rendering.Wpf" version="1.2.4" targetFramework="net461" />
-  <package id="AdaptiveCards.Rendering.Wpf.Xceed" version="1.2.4" targetFramework="net461" />
-  <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net461" />
   <package id="Jot" version="1.4.1" targetFramework="net461" />
   <package id="Microsoft.Bot.Schema" version="4.9.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.0.0" targetFramework="net461" developmentDependency="true" />


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Since it does not have an Open Source license that we can use under our MIT license.
Based on [this document](https://docs.microsoft.com/en-us/adaptive-cards/sdk/rendering-cards/net-wpf/getting-started), I'm positive this is the right change to remove dependency but still have some Adaptive Cards display.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x ] Other... Please describe:
Limit the function of adaptive cards. But I'm not sure yet how.

## How to Test
I made sure there is no regression in Custom Commands applications (which do not use Adaptive Cards).
I have not tested with bots that return Adaptive Cards.
