### PR TITLE
Add language support to c++ sample

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -21,7 +21,8 @@ This is an example config.json file that shows all the common properties. If you
 {
   "SpeechSubscriptionKey": "b587d36063dd458daea151a1b969720a",
   "SpeechRegion": "westus",
-  "SRLanguage": "en-US",  "CustomCommandsAppId": "32d06e92-1bd0-4f3f-2c3b-8cf036d0518f",
+  "SRLanguage": "en-US",  
+  "CustomCommandsAppId": "32d06e92-1bd0-4f3f-2c3b-8cf036d0518f",
   "CustomSREndpointId": "c31ad51b-efef-7ec6-b262-a4be7cd251f2",
   "CustomVoiceDeploymentIds": "53bcf7be-80a2-47dc-2bd3-ba6f62eccfe3",
   "UrlOverride": "",

--- a/clients/cpp-console/configs/config.json
+++ b/clients/cpp-console/configs/config.json
@@ -1,13 +1,14 @@
 {
-  "KeywordRecognitionModel": "/data/cppSample/computer.table",
-  "Keyword": "Computer",
-  "SpeechSubscriptionKey": "YOUR_SUBSCRIPTION_KEY",
-  "SpeechRegion": "YOUR_SUBSCRIPTION_REGION",
-  "Volume": "25",
-  "CustomCommandsAppId": "",
-  "CustomVoiceDeploymentIds": "",
-  "SpeechSDKLogFile": "",
-  "TTSBargeInSupported": "true",
-  "CustomMicConfigPath" :"/home/ubuntu/cpp-console/configs/micConfig.json",
-  "LinuxCaptureDeviceName": "hw:1,0"
+    "KeywordRecognitionModel": "/data/cppSample/computer.table",
+    "Keyword": "Computer",
+    "SpeechSubscriptionKey": "YOUR_SUBSCRIPTION_KEY",
+    "SpeechRegion": "YOUR_SUBSCRIPTION_REGION",
+    "SRLanguage": "en-us",
+    "Volume": "25",
+    "CustomCommandsAppId": "",
+    "CustomVoiceDeploymentIds": "",
+    "SpeechSDKLogFile": "",
+    "TTSBargeInSupported": "true",
+    "CustomMicConfigPath": "/home/ubuntu/cpp-console/configs/micConfig.json",
+    "LinuxCaptureDeviceName": "hw:1,0"
 }

--- a/clients/cpp-console/docs/Windows.md
+++ b/clients/cpp-console/docs/Windows.md
@@ -13,26 +13,27 @@ You will need a Windows 10 PC with Visual Studio 2017 or higher.
 1. Follow the instructions listed above to setup the building and running environment. Besides, get subscription key and key region ready at hand, along with app id if you are using a Custom Commands application.
 
 2. Build the executable from source code:
-* First clone the repository:
-```cmd
-git clone https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistants.git
-```
-* Then change directories:
-```cmd
-cd Cognitive-Services-Voice-Assistants\clients\cpp-console\src\windows
-```
-* Open the Visual Studio solution **clients\cpp-console\src\windows\cppSample.sln** and build the solution (the default build flavor is Debug x64).
-* Open a console Window in the project output folder, e.g. **clients\cpp-console\src\windows\x64\Debug** (for x64 debug build) and see the resulting executable **cppSample.exe** in that folder.
+    * First clone the repository:
+    ```cmd
+    git clone https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistants.git
+    ```
+    * Then change directories:
+    ```cmd
+    cd Cognitive-Services-Voice-Assistants\clients\cpp-console\src\windows
+    ```
+    * Open the Visual Studio solution **clients\cpp-console\src\windows\cppSample.sln** and build the solution (the default build flavor is Debug x64).
+    * Open a console Window in the project output folder, e.g. **clients\cpp-console\src\windows\x64\Debug** (for x64 debug build) and see the resulting executable **cppSample.exe** in that folder.
 
 ## Configure your client
 
-Copy the example configuration file **clients\configs\config.json** into your project output folder and update it as needed. Fill in your subscription key and key region. If you are using a Custom Commands application or a Custom Voice insert those GUID's as well. The KeywordRecognitionModel should point to the Custom Keyword (.table file) being used. You can delete fields that are not required for your setup. Only the SpeechSubscriptionKey and SpeechRegion are required.
+Copy the example configuration file **clients\configs\config.json** into your project output folder and update it as needed. Fill in your subscription key and key region. Fill in the spoken language (en-us being the default). If you are using a Custom Commands application or a Custom Voice insert those GUID's as well. The KeywordRecognitionModel should point to the Custom Keyword (.table file) being used. You can delete fields that are not required for your setup. Only the SpeechSubscriptionKey and SpeechRegion are required.
 ```json
 {
   "KeywordRecognitionModel": "",
   "Keyword": "",
   "SpeechSubscriptionKey": "speech_subscription_key",
   "SpeechRegion": "speech_region",
+  "SRLanguage": "en-us",
   "Volume": "25",
   "CustomCommandsAppId": "custom_commands_app_id",
   "CustomVoiceDeploymentIds": "",

--- a/clients/cpp-console/include/AgentConfiguration.h
+++ b/clients/cpp-console/include/AgentConfiguration.h
@@ -43,6 +43,7 @@ public:
     std::string _customCommandsAppId;
     std::string _speechKey;
     std::string _speechRegion;
+    std::string _srLanguage;
     std::string _customVoiceIds;
     std::string _customSREndpointId;
     std::string _urlOverride;

--- a/clients/cpp-console/src/common/AgentConfiguration.cpp
+++ b/clients/cpp-console/src/common/AgentConfiguration.cpp
@@ -24,6 +24,7 @@ namespace FieldNames
 {
     constexpr auto KeywordRecognitionModel = "KeywordRecognitionModel";
     constexpr auto CustomCommandsAppId = "CustomCommandsAppId";
+    constexpr auto SRLanguage = "SRLanguage";
     constexpr auto SpeechSubscriptionKey = "SpeechSubscriptionKey";
     constexpr auto SpeechRegion = "SpeechRegion";
     constexpr auto CustomVoiceDeploymentIds = "CustomVoiceDeploymentIds";
@@ -59,6 +60,7 @@ shared_ptr<AgentConfiguration> AgentConfiguration::LoadFromFile(const string& pa
 
     config->_customCommandsAppId = j.value(FieldNames::CustomCommandsAppId, "");
     config->_speechKey = j.value(FieldNames::SpeechSubscriptionKey, "");
+    config->_srLanguage = j.value(FieldNames::SRLanguage, "");
     config->_speechRegion = j.value(FieldNames::SpeechRegion, "");
     config->_urlOverride = j.value(FieldNames::UrlOverride, "");
     config->_customVoiceIds = j.value(FieldNames::CustomVoiceDeploymentIds, "");
@@ -180,6 +182,11 @@ shared_ptr<DialogServiceConfig> AgentConfiguration::CreateDialogServiceConfig()
         ? dynamic_pointer_cast<DialogServiceConfig>(CustomCommandsConfig::FromSubscription(_customCommandsAppId, _speechKey, _speechRegion))
         : dynamic_pointer_cast<DialogServiceConfig>(BotFrameworkConfig::FromSubscription(_speechKey, _speechRegion, ""));
 
+    if (_srLanguage.length() > 0)
+    {
+        // Set the speech recognition language. If not set, the default is "en-us".
+        config->SetLanguage(_srLanguage);
+    }
     if (_urlOverride.length() > 0)
     {
         config->SetProperty(PropertyId::SpeechServiceConnection_Endpoint, _urlOverride);


### PR DESCRIPTION
## Purpose
Expose the SRLanguage config param in the C++ sample. It's already supported in the Windows Voice Assistant Client.

Tested against a de-de Custom Command application on Windows. I have not yet tested on RPi4.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

