### PR TITLE
Pass language/calture as HTTP header in Azure function call

### DIFF
--- a/custom-commands/demos/automotive/skill/en-us/AutomotiveDemo.json
+++ b/custom-commands/demos/automotive/skill/en-us/AutomotiveDemo.json
@@ -7,7 +7,8 @@
       "method": "GET",
       "url": "https://automotivedemowidget.azurewebsites.net/api/AutomotiveDemo",
       "headers": {
-        "room": "test1"
+        "room": "test1",
+        "culture": "en-us"
       },
       "sendFrame": false,
       "updateFrame": false

--- a/custom-commands/demos/careroom/skill/en-us/CareRoomDemo.json
+++ b/custom-commands/demos/careroom/skill/en-us/CareRoomDemo.json
@@ -7,7 +7,8 @@
       "method": "GET",
       "url": "https://virtualroommanager.azurewebsites.net/api/CareRoomDemo",
       "headers": {
-        "room": "test1"
+        "room": "test1",
+        "culture": "en-us"
       },
       "sendFrame": false,
       "updateFrame": false

--- a/custom-commands/demos/hospitality/skill/en-us/HospitalityDemo.json
+++ b/custom-commands/demos/hospitality/skill/en-us/HospitalityDemo.json
@@ -7,7 +7,8 @@
       "method": "GET",
       "url": "https://virtualroommanager.azurewebsites.net/api/HospitalityDemo",
       "headers": {
-        "room": "test1"
+        "room": "test1",
+        "culture": "en-us"
       },
       "sendFrame": false,
       "updateFrame": false

--- a/custom-commands/demos/inventory/skill/en-us/InventoryDemo.json
+++ b/custom-commands/demos/inventory/skill/en-us/InventoryDemo.json
@@ -7,7 +7,8 @@
       "method": "GET",
       "url": "https://inventorydemowidget.azurewebsites.net/api/InventoryDemo",
       "headers": {
-        "room": "test1"
+        "room": "test1",
+        "culture": "en-us"
       },
       "sendFrame": true,
       "updateFrame": false

--- a/custom-commands/demos/scripts/deployAll.ps1
+++ b/custom-commands/demos/scripts/deployAll.ps1
@@ -75,9 +75,10 @@ $luisKeyName = "$luisName-authoringkey"
 $storageName = "$resourceName$randomNumber".ToLower()
 $cognitiveservice_speech_name = "$resourceName-speech"
 $luisAuthoringRegion = "westus"
-$CustomCommandsRegion = $region
 $functionURL = "https://$functionName.azurewebsites.net/api/$((Get-Culture).TextInfo.ToTitleCase($appName))Demo"
-$websiteAddress = "https://$functionName.azurewebsites.net/api/$((Get-Culture).TextInfo.ToTitleCase($appName))Demo"
+$customCommandsWebEndpoint = $functionURL
+$customCommandsRegion = $region
+$visualizationEndpoint = "https://$storageName.blob.core.windows.net/www/$appName.html?room=test1"
 
 Write-Host -ForegroundColor Yellow "The deployment will be using default subscription ($subscriptionName) with following details:"
 Write-Host "App name:             $appName"
@@ -87,7 +88,8 @@ Write-Host "Region:               $region"
 Write-Host "LUIS name:            $luisName"
 Write-Host "LUIS Key name:        $luisKeyName"
 Write-Host "Storage name:         $storageName"
-Write-Host "Website address:      $websiteAddress"
+Write-Host "Azure function URL:   $functionURL"
+Write-Host "Visualization URL:    $visualizationEndpoint"
 Write-Host ""
 if ($(Write-Host -ForegroundColor Yellow "Please enter 'y' to proceed, or any other character to quit:"; Read-Host) -ne "y") {
     exit
@@ -119,12 +121,10 @@ $speechResourceKey = $speechResourceKey.key1
 $luisAuthoringKey = az cognitiveservices account keys list -g $resourceName -n $luisKeyName | ConvertFrom-Json
 $luisAuthoringKey = $luisAuthoringKey.key1
 
-$command = "./deployCustomCommands.ps1 -appName $appName -language $language -speechResourceKey $speechResourceKey -resourceName $resourceName -azureSubscriptionId $azureSubscriptionID -resourceGroup $resourceGroup -luisKeyName $luisKeyName -luisAuthoringKey $luisAuthoringKey -luisAuthoringRegion $luisAuthoringRegion -CustomCommandsRegion $CustomCommandsRegion -websiteAddress $websiteAddress"
+$command = "./deployCustomCommands.ps1 -appName $appName -language $language -speechResourceKey $speechResourceKey -resourceName $resourceName -azureSubscriptionId $azureSubscriptionID -resourceGroup $resourceGroup -luisKeyName $luisKeyName -luisAuthoringKey $luisAuthoringKey -luisAuthoringRegion $luisAuthoringRegion -customCommandsRegion $customCommandsRegion -customCommandsWebEndpoint $customCommandsWebEndpoint"
 Write-Host -ForegroundColor Yellow "Calling deployCustomCommands"
 Write-Host -ForegroundColor Yellow $command
 Invoke-Expression $command
-
-$visualizationEndpoint = "https://$storageName.blob.core.windows.net/www/$appName.html?room=test1"
 
 Write-Host "    Speech Region = $region"
 Write-Host "***********************"

--- a/custom-commands/demos/scripts/deployCustomCommands.ps1
+++ b/custom-commands/demos/scripts/deployCustomCommands.ps1
@@ -10,8 +10,8 @@ Param(
     [string] $luisAuthoringKey = $(Read-Host -prompt "luisAuthoringKey"),
     [string] $luisAuthoringRegion = "westus",
     [string] $luisKeyName = $(Read-Host -prompt "luisKeyName"),
-    [string] $CustomCommandsRegion = "westus2",
-    [string] $websiteAddress = $(Read-Host -prompt "websiteAddress")
+    [string] $customCommandsRegion = "westus2",
+    [string] $customCommandsWebEndpoint = $(Read-Host -prompt "cutomCommandsWebEndpoint")
 )
 
 [Console]::ResetColor()
@@ -46,7 +46,7 @@ $headers = @{
 }
 
 try {
-    $response = invoke-restmethod -Method POST -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/apps" -Body (ConvertTo-Json $body) -Header $headers
+    $response = invoke-restmethod -Method POST -Uri "https://$customCommandsRegion.commands.speech.microsoft.com/apps" -Body (ConvertTo-Json $body) -Header $headers
 }
 catch {
     # dig into the exception to get the Response details.
@@ -67,12 +67,12 @@ write-host "Created project Id $appId"
 # change the model based on the local json file
 write-host "patching the $speechAppName $appName commands model"
 $newModel = Get-Content $skillJson | Out-String | ConvertFrom-Json
-$newModel.webEndpoints[0].url = $websiteAddress
+$newModel.webEndpoints[0].url = $customCommandsWebEndpoint
 
 # send the updated model up to the application
 write-host "updating $speechAppName with the new $appName commands model"
 try {
-    $response = invoke-restmethod -Method PUT -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/v1.0/apps/$appId/slots/default/languages/en-us/model" -Body ($newModel | ConvertTo-Json  -depth 100) -Header $headers
+    $response = invoke-restmethod -Method PUT -Uri "https://$customCommandsRegion.commands.speech.microsoft.com/v1.0/apps/$appId/slots/default/languages/en-us/model" -Body ($newModel | ConvertTo-Json  -depth 100) -Header $headers
 }
 catch {
     # dig into the exception to get the Response details.
@@ -89,7 +89,7 @@ write-host "...model update completed"
 #
 
 write-host "starting the training"
-$response = invoke-webrequest -Method POST -Uri "https://$CustomCommandsRegion.commands.speech.microsoft.com/v1.0/apps/$appId/slots/default/languages/en-us/train?force=true" -Header $headers
+$response = invoke-webrequest -Method POST -Uri "https://$customCommandsRegion.commands.speech.microsoft.com/v1.0/apps/$appId/slots/default/languages/en-us/train?force=true" -Header $headers
 $OperationLocation = $response.Headers["Operation-Location"]
 write-host -NoNewline "training Operation Location: $OperationLocation"
 


### PR DESCRIPTION
## Purpose
Pass language/culture as HTTP header in Azure function call, so the Azure function can reply with the correct language. The change in the Azure function will be in a separate PR.
Also clean up variable names in the script and remove duplicates.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```
