### PR TITLE
Update Custom Commands deployment script

### DIFF
--- a/custom-commands/demos/README.md
+++ b/custom-commands/demos/README.md
@@ -66,16 +66,19 @@ If you see errors while running the script, refer to the [Troubleshooting](#trou
 
 On a successful completion, you should see a message at the end similar to the following, with all the information you need to configure one of the selected [Voice Assistant client samples](https://github.com/Azure-Samples/Cognitive-Services-Voice-Assistant#sample-client-applications), and a URL to visualize the results of your voice commands:
 ```console
-***********************
-Custom commands has been published.
-Update these parameters in your client to use the Custom Commands Application
-    CustomCommandsId = ########-####-####-####-############
+*******************************************************************
+
+ Your Custom Commands demo has been published!
+
+ Customized your client app with the following, in order to connect:
+    CustomCommandsAppId   = ########-####-####-####-############
     SpeechSubscriptionKey = ################################
-    Speech Region = westus
-***********************
-To view your visualization go to this link.
-    Visualization Endpoint = https://#########.blob.core.windows.net/www/demo.html?room=test1
-***********************
+    SpeechRegion          = westus
+
+ To visualize the demo scene, point your browser to this address:
+    https://#########.blob.core.windows.net/www/hospitality.html?room=test1
+
+*******************************************************************
 ```
 Copy the above information and store it for later use (but you can always [retrieve it if needed](#retrieving-client-connection-information-and-visualization-URL))
 
@@ -83,12 +86,12 @@ If you now look at your [Azure Resource groups](https://portal.azure.com/#blade/
 
 | Name  | Type          | Usage
 | ------- | ---------------- | --- |
-| MyResourceGroupName-####  | Cognitive Services | LUIS runtime (API type "Language Understanding (LUIS)")
-| MyResourceGroupName-#### | App Service | Required to host the Azure function
-| MyResourceGroupName-####-authoringkey | Cognitive Services | LUIS authoring (API type Language Understanding Authoring (LUIS))
-| MyResourceGroupName-serverfarm | App Service Plan | Required to host the Azure function
-| MyResourceGroupName-speech | Cognitive Services | Speech resource, where you get the speech subscription key
-| MyResourceGroupName#### | Storage account | Stores HTML and supporting .png files for scene visualization
+| MyResourceGroupName-####             | Function App       | Required to host the Azure function
+| MyResourceGroupName-authoring-####   | Cognitive Services | LUIS authoring. API type "Language Understanding Authoring (LUIS)"
+| MyResourceGroupName-prediction-####  | Cognitive Services | LUIS runtime (aka "prediction"). API type "Language Understanding (LUIS)"
+| MyResourceGroupName-serverfarm       | App Service Plan   | Required to host the Azure function
+| MyResourceGroupName-speech           | Cognitive Services | Speech resource, where you get the speech subscription key
+| MyResourceGroupName####              | Storage account    | Stores HTML and supporting .png files for scene visualization
 
 ## Make sure the visualization works properly
 

--- a/custom-commands/demos/scripts/azuredeploy.json
+++ b/custom-commands/demos/scripts/azuredeploy.json
@@ -5,7 +5,10 @@
         "resourceName": {
             "type": "string"
         },
-        "luisName": {
+        "luisPredictionName": {
+            "type": "string"
+        },
+        "luisAuthoringName": {
             "type": "string"
         },
         "functionName": {
@@ -17,8 +20,8 @@
     },
     "variables": {
         "cognitiveservice_speech_name": "[concat(parameters('resourceName'),'-speech')]",
-        "cognitiveservice_luis_name": "[parameters('luisName')]",
-        "cognitiveservice_luis_authoringkey_name": "[concat(parameters('luisName'),'-authoringkey')]",
+        "cognitiveservice_luis_prediction_name": "[parameters('luisPredictionName')]",
+        "cognitiveservice_luis_authoring_name": "[parameters('luisAuthoringName')]",
         "server_farm_name": "[concat(parameters('resourceName'),'-serverfarm')]",
         "visualdemo_name": "[parameters('functionName')]",
         "storage_name": "[toLower(parameters('storageName'))]"
@@ -27,27 +30,27 @@
         {
             "type": "Microsoft.CognitiveServices/accounts",
             "apiVersion": "2017-04-18",
-            "name": "[variables('cognitiveservice_luis_name')]",
+            "name": "[variables('cognitiveservice_luis_prediction_name')]",
             "location": "[resourceGroup().location]",
             "sku": {
                 "name": "S0"
             },
             "kind": "LUIS",
             "properties": {
-                "customSubDomainName": "[variables('cognitiveservice_luis_name')]"
+                "customSubDomainName": "[variables('cognitiveservice_luis_prediction_name')]"
             }
         },
         {
             "type": "Microsoft.CognitiveServices/accounts",
             "apiVersion": "2017-04-18",
-            "name": "[variables('cognitiveservice_luis_authoringkey_name')]",
+            "name": "[variables('cognitiveservice_luis_authoring_name')]",
             "location": "west us",
             "sku": {
                 "name": "F0"
             },
             "kind": "LUIS.Authoring",
             "properties": {
-                "customSubDomainName": "[variables('cognitiveservice_luis_authoringkey_name')]"
+                "customSubDomainName": "[variables('cognitiveservice_luis_authoring_name')]"
             }
         },
         {

--- a/custom-commands/demos/scripts/azuredeploy.parameters.json
+++ b/custom-commands/demos/scripts/azuredeploy.parameters.json
@@ -3,16 +3,19 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "resourceName": {
-      "value": "AZURE_RESOURCE_NAME"
+      "value": "PLACEHOLDER"
     },
-    "luisName": {
-      "value": "AZURE_RESOURCE_NAME-####"
+    "luisPredictionName": {
+      "value": "PLACEHOLDER"
+    },
+    "luisAuthoringName": {
+      "value": "PLACEHOLDER"
     },
     "functionName": {
-      "value": "AZURE_RESOURCE_NAME-####"
+      "value": "PLACEHOLDER"
     },
     "storageName": {
-      "value": "AZURE_RESOURCE_NAME####"
+      "value": "PLACEHOLDER"
     }
   }
 }

--- a/custom-commands/demos/scripts/deployAll.ps1
+++ b/custom-commands/demos/scripts/deployAll.ps1
@@ -92,7 +92,7 @@ if ($(Write-Host -ForegroundColor Yellow "Please enter 'y' to proceed, or any ot
     exit
 }
 
-$command = ".\deployTemplate.ps1 -resourceName $resourceName -region $region -luisName $luisPrediction -functionName $functionName -storageName $storageName"
+$command = ".\deployTemplate.ps1 -resourceName $resourceName -region $region -luisPrediction $luisPrediction -luisAuthoring $luisAuthoring -functionName $functionName -storageName $storageName"
 Write-Host -ForegroundColor Yellow "Calling deployTemplate"
 Write-Host -ForegroundColor Yellow "$command"
 Invoke-Expression $command
@@ -125,7 +125,7 @@ Invoke-Expression $command
 Write-Host "    SpeechSubscriptionKey = $speechResourceKey"
 Write-Host "    SpeechRegion          = $region"
 Write-Host
-Write-Host "To view your visualization point your browser to this address:"
-Write-Host "    Visualization Endpoint = $visualizationEndpoint"
+Write-Host " To visualize the demo scene, point your browser to this address:"
+Write-Host "    $visualizationEndpoint"
 Write-Host
 Write-Host "*******************************************************************"

--- a/custom-commands/demos/scripts/deployAll.ps1
+++ b/custom-commands/demos/scripts/deployAll.ps1
@@ -68,6 +68,11 @@ if ($output -eq $true) {
     exit
 }
 
+#
+# TODO:
+# rename luisKeyName to luisAuthoring
+# rename luisName to luisPrediction
+
 $resourceGroup = $resourceName
 $functionName = "$resourceName-$randomNumber"
 $luisName = "$resourceName-$randomNumber"
@@ -110,24 +115,25 @@ Write-Host -ForegroundColor Yellow "Calling deployAzureFunction"
 Write-Host -ForegroundColor Yellow "$command"
 Invoke-Expression $command
 
-# get the keys we need for the custom command deployment
-Write-Host "Getting new keys"
-Write-Host "resource name = $resourceName"
-Write-Host "speech name = $cognitiveservice_speech_name"
-Write-Host "luis name = $luisKeyName"
+Write-Host "Getting additional Azure resouces needed to deploy a new Custom Command project"
 $speechResourceKey = az cognitiveservices account keys list -g $resourceName -n $cognitiveservice_speech_name | ConvertFrom-Json
 $speechResourceKey = $speechResourceKey.key1
 
-$luisAuthoringKey = az cognitiveservices account keys list -g $resourceName -n $luisKeyName | ConvertFrom-Json
-$luisAuthoringKey = $luisAuthoringKey.key1
+$luisPredictionResourceId = az cognitiveservices account show -g $resourceName -n $luisName | ConvertFrom-JSon 
+$luisPredictionResourceId = $luisPredictionResourceId.id
 
-$command = "./deployCustomCommands.ps1 -appName $appName -language $language -speechResourceKey $speechResourceKey -resourceName $resourceName -azureSubscriptionId $azureSubscriptionID -resourceGroup $resourceGroup -luisKeyName $luisKeyName -luisAuthoringKey $luisAuthoringKey -luisAuthoringRegion $luisAuthoringRegion -customCommandsRegion $customCommandsRegion -customCommandsWebEndpoint $customCommandsWebEndpoint"
+$luisAuthoringResourceId = az cognitiveservices account show -g $resourceName -n $luisKeyName | ConvertFrom-JSon 
+$luisAuthoringResourceId = $luisAuthoringResourceId.id
+
+$command = "./deployCustomCommands.ps1 -appName $appName -language $language -speechResourceKey $speechResourceKey -resourceName $resourceName -azureSubscriptionId $azureSubscriptionID -resourceGroup $resourceGroup -luisKeyName $luisKeyName -luisAuthoringResourceId $luisAuthoringResourceId -luisAuthoringRegion $luisAuthoringRegion -luisPredictionResourceId $luisPredictionResourceId -customCommandsRegion $customCommandsRegion -customCommandsWebEndpoint $customCommandsWebEndpoint"
 Write-Host -ForegroundColor Yellow "Calling deployCustomCommands"
 Write-Host -ForegroundColor Yellow $command
 Invoke-Expression $command
 
-Write-Host "    Speech Region = $region"
-Write-Host "***********************"
-Write-Host "To view your visualization go to this link."
+Write-Host "    SpeechSubscriptionKey = $speechResourceKey"
+Write-Host "    SpeechRegion          = $region"
+Write-Host
+Write-Host "To view your visualization point your browser to this address:"
 Write-Host "    Visualization Endpoint = $visualizationEndpoint"
-Write-Host "***********************"
+Write-Host
+Write-Host "*******************************************************************"

--- a/custom-commands/demos/scripts/deployAll.ps1
+++ b/custom-commands/demos/scripts/deployAll.ps1
@@ -128,7 +128,7 @@ $luisAuthoringResourceId = $luisAuthoringResourceId.id
 $command = "./deployCustomCommands.ps1 -appName $appName -language $language -speechResourceKey $speechResourceKey -resourceName $resourceName -azureSubscriptionId $azureSubscriptionID -resourceGroup $resourceGroup -luisKeyName $luisKeyName -luisAuthoringResourceId $luisAuthoringResourceId -luisAuthoringRegion $luisAuthoringRegion -luisPredictionResourceId $luisPredictionResourceId -customCommandsRegion $customCommandsRegion -customCommandsWebEndpoint $customCommandsWebEndpoint"
 Write-Host -ForegroundColor Yellow "Calling deployCustomCommands"
 Write-Host -ForegroundColor Yellow $command
-Invoke-Expression $command
+# Invoke-Expression $command
 
 Write-Host "    SpeechSubscriptionKey = $speechResourceKey"
 Write-Host "    SpeechRegion          = $region"

--- a/custom-commands/demos/scripts/deployCustomCommands.ps1
+++ b/custom-commands/demos/scripts/deployCustomCommands.ps1
@@ -85,7 +85,7 @@ catch {
 write-host "Starting the model training"
 $response = invoke-webrequest -Method POST -Uri "https://$region.commands.speech.microsoft.com/v1.0/apps/$appId/slots/default/languages/$language/train?force=true" -Header $headers
 $OperationLocation = $response.Headers["Operation-Location"]
-write-host -NoNewline "training Operation Location: $OperationLocation"
+write-host "training Operation Location: $OperationLocation"
 
 #
 # Wait until the training is complete
@@ -134,8 +134,9 @@ write-host "...model is published"
 
 Write-Host
 Write-Host "*******************************************************************"
-Write-Host "Your Custom Commands demo has been published!"
 Write-Host
-Write-Host "Customized your client app with the following, in order to connect:"
+Write-Host " Your Custom Commands demo has been published!"
+Write-Host
+Write-Host " Customized your client app with the following, in order to connect:"
 Write-Host "    CustomCommandsAppId   = $appId"
 

--- a/custom-commands/demos/scripts/deployCustomCommands.ps1
+++ b/custom-commands/demos/scripts/deployCustomCommands.ps1
@@ -15,7 +15,7 @@ Param(
 $ErrorActionPreference = "Stop"
 
 #
-# Create and provision a new Custom Command project
+# Create and provision a new Custom Command application
 #
 
 $customCommandsAppName = "$resourceName-commands"

--- a/custom-commands/demos/scripts/deployTemplate.ps1
+++ b/custom-commands/demos/scripts/deployTemplate.ps1
@@ -1,6 +1,7 @@
 Param(
     [string] $resourceName = $(Read-Host -prompt "resourceName"),
-    [string] $luisName = $(Read-Host -prompt "luisName"),
+    [string] $luisPredictionName = $(Read-Host -prompt "luisPrediction"),
+    [string] $luisAuthoringName = $(Read-Host -prompt "luisAuthoring"),
     [string] $functionName = $(Read-Host -prompt "functionName"),
     [string] $storageName = $(Read-Host -prompt "storageName"),
     [string] $region = $(Read-Host -prompt "region")
@@ -13,7 +14,8 @@ $ErrorActionPreference = "Stop"
 $tempParametersFile = './temp.azuredeploy.parameters.json'
 $newContent = (Get-Content './azuredeploy.parameters.json') | Out-String | ConvertFrom-Json
 $newContent.parameters.resourceName.value = $resourceName
-$newContent.parameters.luisName.value = $luisName
+$newContent.parameters.luisPredictionName.value = $luisPredictionName
+$newContent.parameters.luisAuthoringName.value = $luisAuthoringName
 $newContent.parameters.functionName.value = $functionName
 $newContent.parameters.storageName.value = $storageName
 $newContent | ConvertTo-Json -depth 100 | Set-Content $tempParametersFile


### PR DESCRIPTION
## Purpose
* The first REST call in the deployCustomCommands.ps1 script was still using a preview version of the Custom Command web API. Switch to using 1.0 API. 
* The switch to 1.0 API meant that we no longer send the LUIS prediction and authoring keys. We now send a token replacement instead.
* The first REST call in deployCustomCommands.ps1 now both creates a new Custom Command project and provisions it with the JSON model of the project. Previously this was done by two separate calls
* Update parameter names in the scripts. In particular, make it clear what is a LUIS runtime (aka prediction) and what is LUIS authoring Azure resource. Remove the word "key" when it was not really pointing to a secrete key, but Azure resource name
* Other cleanup and simplifications
* Update doc to reflect the above changes.

The above switch to 1.0 web API fixes a regression that happened a few days ago. 

I tested by deploying two demos, the hospitality & inventory in my own Azure subscription.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
