### PR TITLE
Changed to pullstream for SDK wav audio

### DIFF
--- a/clients/csharp-dotnet-core/voice-assistant-test/README.md
+++ b/clients/csharp-dotnet-core/voice-assistant-test/README.md
@@ -108,6 +108,9 @@ Here is the full list:
 >#### KeywordVerificationEnabled
 >`bool | optional | false | true`. A boolean which indicates if your bot or custom command application is configured to use keyword verification. The default value is `true`. Note that if a [CustomSREndpointId](#customsrendpointid) is specified, this value is ignored and keyword verification is automatically disabled.
 
+>#### PushStreamEnabled
+>`bool | optional | false | true`. A boolean which indicates if the test should use a "push" stream to interact with the Speech SDK. The default value is `false`. This can be useful in making sure the tests mimic your application.
+
 >#### AriaProjectKey
 >`sring | optional | null | "0123456789abcdef0123456789abcdef-01234567-890a-bcde-f012-34567890abcd-ef01"`. An optional Aria project key. If given, dialog success and failure events will be sent to the Aria cloud. For more information on Aria, see [https://www.aria.ms/](https://www.aria.ms/).
 

--- a/clients/csharp-dotnet-core/voice-assistant-test/docs/json-templates/app-config-template.json
+++ b/clients/csharp-dotnet-core/voice-assistant-test/docs/json-templates/app-config-template.json
@@ -31,6 +31,7 @@
   "Timeout":  5000,
   "KeywordRecognitionModel" : "",
   "KeywordVerificationEnabled": true,
+  "PushStreamEnabled": false,
   "SetPropertyId": {},
   "SetPropertyString": {},
   "SetServiceProperty":{}

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/AppSettings.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/AppSettings.cs
@@ -120,6 +120,11 @@ namespace VoiceAssistantTest
         public string KeywordRecognitionModel { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to use a push stream instead of a pull stream.
+        /// </summary>
+        public bool PushStreamEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets the SetPropertyID.
         /// This will result in SetPropery method call on DialogServiceConfig that takes a PropertyId argument.
         /// </summary>

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/BotConnector.cs
@@ -45,6 +45,7 @@ namespace VoiceAssistantTest
         private bool keyword;
         private KeywordRecognitionModel kwsTable;
         private int speechDuration = 0;
+        private AudioConfig audioConfig = AudioConfig.FromStreamInput(GlobalPullStream.FilePullStreamCallback);
 
         /// <summary>
         /// Gets or sets recognized text of the speech input.
@@ -161,9 +162,18 @@ namespace VoiceAssistantTest
                 this.connector = null;
             }
 
-            this.pushAudioInputStream = AudioInputStream.CreatePushStream();
-            this.connector = new DialogServiceConnector(config, AudioConfig.FromStreamInput(this.pushAudioInputStream));
+            if (this.appsettings.PushStreamEnabled)
+            {
+                this.pushAudioInputStream = AudioInputStream.CreatePushStream();
+                this.audioConfig = AudioConfig.FromStreamInput(this.pushAudioInputStream);
+            }
+            else
+            {
+                config.SetProperty("KeywordConfig_EnableKeywordVerification", "false");
+                this.audioConfig = AudioConfig.FromStreamInput(GlobalPullStream.FilePullStreamCallback);
+            }
 
+            this.connector = new DialogServiceConnector(config, this.audioConfig);
             if (this.appsettings.BotGreeting)
             {
                 // Starting the timer to calculate latency for Bot Greeting.
@@ -237,26 +247,33 @@ namespace VoiceAssistantTest
         /// <param name="wavFile">WAV File in each turn.</param>
         public void ReadAudio(string wavFile)
         {
-            int readBytes;
-
             lock (this.BotReplyList)
             {
                 this.BotReplyList.Clear();
                 this.indexActivityWithAudio = 0;
             }
 
-            byte[] dataBuffer = new byte[MaxSizeOfTtsAudioInBytes];
-            WaveFileReader waveFileReader = new WaveFileReader(Path.Combine(this.appsettings.InputFolder, wavFile));
-
-            // Reading header bytes
-            int headerBytes = waveFileReader.Read(dataBuffer, 0, WavHeaderSizeInBytes);
-
-            while ((readBytes = waveFileReader.Read(dataBuffer, 0, BytesToRead)) > 0)
+            if (this.appsettings.PushStreamEnabled)
             {
-                this.pushAudioInputStream.Write(dataBuffer, readBytes);
-            }
+                int readBytes;
 
-            waveFileReader.Dispose();
+                byte[] dataBuffer = new byte[MaxSizeOfTtsAudioInBytes];
+                WaveFileReader waveFileReader = new WaveFileReader(Path.Combine(this.appsettings.InputFolder, wavFile));
+
+                // Reading header bytes
+                int headerBytes = waveFileReader.Read(dataBuffer, 0, WavHeaderSizeInBytes);
+
+                while ((readBytes = waveFileReader.Read(dataBuffer, 0, BytesToRead)) > 0)
+                {
+                    this.pushAudioInputStream.Write(dataBuffer, readBytes);
+                }
+
+                waveFileReader.Dispose();
+            }
+            else
+            {
+                GlobalPullStream.FilePullStreamCallback.ReadFile(Path.Combine(this.appsettings.InputFolder, wavFile));
+            }
         }
 
         /// <summary>
@@ -391,7 +408,11 @@ namespace VoiceAssistantTest
         {
             this.kwsTable?.Dispose();
             this.connector.Dispose();
-            this.pushAudioInputStream.Dispose();
+            this.audioConfig.Dispose();
+            if (this.appsettings.PushStreamEnabled)
+            {
+                this.pushAudioInputStream.Dispose();
+            }
         }
 
         /// <summary>

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.CognitiveServices.Speech.Audio;
+using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading;
+
+namespace VoiceAssistantTest
+{
+    enum FileReadStatus
+    {
+        HASDATA,
+        NODATA
+    }
+
+    class FilePullStreamCallback : PullAudioInputStreamCallback
+    {
+        public bool realTime = true;
+
+        private const int MaxSizeOfTtsAudioInBytes = 65536;
+        private const int WavHeaderSizeInBytes = 44;
+        private FileReadStatus fileReadStatus = FileReadStatus.NODATA;
+        private FileStream currentFileStream = null;
+        private string filepath = string.Empty;
+        private int mBytesPerSecond = 32000;
+        private int totalTimeRead = 0;
+
+        public override int Read(byte[] dataBuffer, uint size)
+        {
+            switch (this.fileReadStatus)
+            {
+                case FileReadStatus.HASDATA:
+                    // read the data from the file
+                    var readTime = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+                    int readBytes = this.currentFileStream.Read(dataBuffer, 0, (int)size);
+                    readTime = (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - readTime;
+                    if (readBytes == 0)
+                    {
+                        // we are at end of file
+                        this.fileReadStatus = FileReadStatus.NODATA;
+                        Array.Clear(dataBuffer, 0, (int)size);
+                        this.currentFileStream.Close();
+                        this.currentFileStream.Dispose();
+                        this.currentFileStream = null;
+                        return (int)size;
+                    }
+                    else
+                    {
+                        if (this.realTime)
+                        {
+                            this.totalTimeRead += 1000 * (int)Math.Round((double)readBytes / this.mBytesPerSecond);
+                            int timeToSleep = (int)Math.Round((1000 * ((double)readBytes / this.mBytesPerSecond)) - readTime);
+                            Thread.Sleep(timeToSleep);
+                        }
+
+                        return readBytes;
+                    }
+
+                case FileReadStatus.NODATA:
+                default:
+                    Array.Clear(dataBuffer, 0, (int)size);
+                    return (int)size;
+            }
+        }
+
+        public void ReadFile(string filepath)
+        {
+            if (this.currentFileStream != null)
+            {
+                this.currentFileStream.Close();
+                this.currentFileStream = null;
+            }
+
+            this.currentFileStream = File.OpenRead(filepath);
+
+            byte[] dataBuffer = new byte[WavHeaderSizeInBytes];
+
+            // Reading header bytes
+            int headerBytes = this.currentFileStream.Read(dataBuffer, 0, WavHeaderSizeInBytes);
+            this.fileReadStatus = FileReadStatus.HASDATA;
+        }
+
+        public override void Close()
+        {
+            base.Close();
+        }
+
+        public void Dispose()
+        {
+            if (this.currentFileStream != null)
+            {
+                this.currentFileStream.Close();
+                this.currentFileStream = null;
+            }
+        }
+    }
+}

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
@@ -1,33 +1,49 @@
-﻿using Microsoft.CognitiveServices.Speech.Audio;
-using NAudio.Wave;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq.Expressions;
-using System.Text;
-using System.Threading;
-
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 namespace VoiceAssistantTest
 {
-    enum FileReadStatus
-    {
-        HASDATA,
-        NODATA
-    }
+    using System;
+    using System.IO;
+    using System.Threading;
+    using Microsoft.CognitiveServices.Speech.Audio;
 
-    class FilePullStreamCallback : PullAudioInputStreamCallback
+    /// <summary>
+    /// This class works as a pull stream for the speech SDK that you can feed files to. When the speech SDK is looking for
+    /// audio data, it will call this read function. The read function is responsible for writing bytes to the passed in buffer
+    /// and returning the number of valid bytes in that buffer.
+    ///
+    /// When ReadFile is called, it will setup a filestream that will be read from on the next Read call. When the filestream is empty,
+    /// an array of 0's will be returned to simulate silence.
+    ///
+    /// If realTime is set to true, this class will sleep for the appropriate amount of time for each audio clip.
+    /// </summary>
+    public class FilePullStreamCallback : PullAudioInputStreamCallback
     {
-        public bool realTime = true;
-
-        private const int MaxSizeOfTtsAudioInBytes = 65536;
         private const int WavHeaderSizeInBytes = 44;
+        private bool realTime = false;
         private FileReadStatus fileReadStatus = FileReadStatus.NODATA;
         private FileStream currentFileStream = null;
-        private string filepath = string.Empty;
         private int mBytesPerSecond = 32000;
-        private int totalTimeRead = 0;
 
+        private enum FileReadStatus
+        {
+            HASDATA,
+            NODATA,
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the pullStream should sleep based
+        /// on the number of bytes read to simulate real time audio.
+        /// </summary>
+        public bool RealTime { get => this.realTime; set => this.realTime = value; }
+
+        /// <summary>
+        /// This function is called by the speech SDK when audio is required. It will fill the parameter buffer with any audio file data
+        /// available. If no data is available it will write 0's to simulate silence.
+        /// </summary>
+        /// <param name="dataBuffer">The buffer to place the data in.</param>
+        /// <param name="size">The size of the buffer.</param>
+        /// <returns>An int indicating the number of bytes placed in the buffer.</returns>
         public override int Read(byte[] dataBuffer, uint size)
         {
             switch (this.fileReadStatus)
@@ -35,7 +51,12 @@ namespace VoiceAssistantTest
                 case FileReadStatus.HASDATA:
                     // read the data from the file
                     var readTime = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-                    int readBytes = this.currentFileStream.Read(dataBuffer, 0, (int)size);
+                    int readBytes = 0;
+                    if (this.currentFileStream != null)
+                    {
+                        readBytes = this.currentFileStream.Read(dataBuffer, 0, (int)size);
+                    }
+
                     readTime = (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - readTime;
                     if (readBytes == 0)
                     {
@@ -45,13 +66,13 @@ namespace VoiceAssistantTest
                         this.currentFileStream.Close();
                         this.currentFileStream.Dispose();
                         this.currentFileStream = null;
+                        Thread.Sleep(100);
                         return (int)size;
                     }
                     else
                     {
-                        if (this.realTime)
+                        if (this.RealTime)
                         {
-                            this.totalTimeRead += 1000 * (int)Math.Round((double)readBytes / this.mBytesPerSecond);
                             int timeToSleep = (int)Math.Round((1000 * ((double)readBytes / this.mBytesPerSecond)) - readTime);
                             Thread.Sleep(timeToSleep);
                         }
@@ -62,10 +83,15 @@ namespace VoiceAssistantTest
                 case FileReadStatus.NODATA:
                 default:
                     Array.Clear(dataBuffer, 0, (int)size);
+                    Thread.Sleep(100);
                     return (int)size;
             }
         }
 
+        /// <summary>
+        /// This function will read the wav header off of the file and setup the file stream for the SpeechSDK to read it.
+        /// </summary>
+        /// <param name="filepath">The absolute path to the file to read.</param>
         public void ReadFile(string filepath)
         {
             if (this.currentFileStream != null)
@@ -83,18 +109,18 @@ namespace VoiceAssistantTest
             this.fileReadStatus = FileReadStatus.HASDATA;
         }
 
-        public override void Close()
-        {
-            base.Close();
-        }
-
-        public void Dispose()
+        /// <summary>
+        /// Disposes the underlying resources.
+        /// </summary>
+        public new void Dispose()
         {
             if (this.currentFileStream != null)
             {
                 this.currentFileStream.Close();
                 this.currentFileStream = null;
             }
+
+            base.Dispose();
         }
     }
 }

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/FilePullStreamCallback.cs
@@ -33,7 +33,7 @@ namespace VoiceAssistantTest
 
         /// <summary>
         /// Gets or sets a value indicating whether the pullStream should sleep based
-        /// on the number of bytes read to simulate real time audio.
+        /// on the number of bytes read to simulate real time audio. The SDK has a similar feature. This one is not exposed.
         /// </summary>
         public bool RealTime { get => this.realTime; set => this.realTime = value; }
 

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/GlobalPullStream.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/GlobalPullStream.cs
@@ -7,7 +7,6 @@ namespace VoiceAssistantTest
     /// </summary>
     public static class GlobalPullStream
     {
-
         private static FilePullStreamCallback filePullStreamCallback = new FilePullStreamCallback();
 
         /// <summary>

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/GlobalPullStream.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/GlobalPullStream.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+namespace VoiceAssistantTest
+{
+    /// <summary>
+    /// This class provides a static access to a single FilePullStreamCallback.
+    /// </summary>
+    public static class GlobalPullStream
+    {
+
+        private static FilePullStreamCallback filePullStreamCallback = new FilePullStreamCallback();
+
+        /// <summary>
+        /// Gets the object referring to the global FilePullStreamCallback.
+        /// </summary>
+        public static FilePullStreamCallback FilePullStreamCallback { get => filePullStreamCallback; }
+    }
+}

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
@@ -9,6 +9,7 @@ namespace VoiceAssistantTest
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -439,8 +440,6 @@ namespace VoiceAssistantTest
                 await botConnector.Disconnect().ConfigureAwait(false);
                 botConnector.Dispose();
             }
-
-            Thread.Sleep(1000);
 
             return testPass;
         }

--- a/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
+++ b/clients/csharp-dotnet-core/voice-assistant-test/tool/MainService.cs
@@ -10,6 +10,7 @@ namespace VoiceAssistantTest
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
     using VoiceAssistantTest.Resources;
@@ -431,6 +432,15 @@ namespace VoiceAssistantTest
 #endif
                 }
             } // End of dialog loop
+
+            // Always clean up our connector object
+            if (botConnector != null)
+            {
+                await botConnector.Disconnect().ConfigureAwait(false);
+                botConnector.Dispose();
+            }
+
+            Thread.Sleep(1000);
 
             return testPass;
         }


### PR DESCRIPTION
## Purpose
This PR makes the default method of injecting wav files a "pullstream" instead of a "pushstream". This seems to work much better for large sets of tests. Push stream can now be used as an option in the config file.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
