### PR TITLE
Force light theme in UWP Client App

### DIFF
--- a/clients/csharp-uwp/UWPVoiceAssistantSample/App.xaml
+++ b/clients/csharp-uwp/UWPVoiceAssistantSample/App.xaml
@@ -2,7 +2,8 @@
     x:Class="UWPVoiceAssistantSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UWPVoiceAssistantSample">
+    xmlns:local="using:UWPVoiceAssistantSample"
+    RequestedTheme="Light">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
When Windows 10 is set to dark mode, some fonts and app colors were automatically changed making the app unreadable in some sections. This forces the app to run in Light mode independent of system settings, which is readable.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* App should always have a white background throughout, and chat bubble text in right-most panel should be black.

## Other Information
<!-- Add any other helpful information that may be needed here. -->