### PR TITLE
Update readme for dot net version

### DIFF
--- a/custom-commands/demos/README.md
+++ b/custom-commands/demos/README.md
@@ -5,7 +5,7 @@
 * Powershell 6.0 or greater. [Download Powershell here](https://github.com/PowerShell/PowerShell/releases). 
     * On Windows, download and run an .msi file (e.g. "PowerShell-7.0.0-win-x64.msi")
 * Azure CLI. [Insall Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) version 2.4.0 or higher.
-* .NET Core SDK 2.1 or higher. [Install SDK here](https://docs.microsoft.com/en-us/dotnet/core/install/sdk?pivots=os-windows).
+* .NET Core SDK 2.1 [Install SDK here](https://docs.microsoft.com/en-us/dotnet/core/install/sdk?pivots=os-windows).
 
 ## What are you deploying?
 


### PR DESCRIPTION
I tried DotNet SDK 5.0 didn't work due to custom command requires DotNet core 2.1 to build.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Refine demo readme. Explicitly requrie dot net core 2.1 as SDK.
I tried .net 5.0 SDK offline and it didn't work since the CC requires .net core 2.1 to build

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid

## Other Information
<!-- Add any other helpful information that may be needed here. -->