### PR TITLE
Added error printouts for some messages when initializing the windows…

### DIFF
--- a/clients/cpp-console/include/AudioPlayer.h
+++ b/clients/cpp-console/include/AudioPlayer.h
@@ -29,7 +29,8 @@ public:
     enum class AudioPlayerFormat
     {
         Mono16khz16bit,
-        Stereo48khz16bit
+        Stereo48khz16bit,
+        GetFromWindows
     };
 
     /// <summary>


### PR DESCRIPTION
… audio player. Also added a "format" that gets the audio wave format from windows.

## Purpose
It seems windows 11 reworked their audioClient and the default stream doesn't play correctly. I didn't add code to show how to request the proper format from the service, but that would be the next step.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```